### PR TITLE
restore AG-UI state from frontend in SkillToolset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **AG-UI state restoration**: `SkillToolset` now restores skill namespace state from frontend-provided `deps.state` on each AG-UI request, so state survives server restarts
+
 ## [0.4.0] - 2026-02-19
 
 ### Added


### PR DESCRIPTION
Override get_tools() to read state from ctx.deps and call restore_state_snapshot(), so skill namespace state survives server restarts when used with AGUIAdapter. Identity check ensures restore happens once per request, not per model step.