### PR TITLE
Add JS/TS script support to run_script

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version-file: "pyproject.toml"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "lts/*"
+      - name: Install tsx
+        run: npm install -g tsx
       - name: Install dependencies
         run: uv sync --all-extras
       - name: Run tests with coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 - **`skill_model` parameter**: `SkillToolset` accepts `skill_model` to set the model for skill sub-agents (also available as `--skill-model` CLI option)
 - **`resolve_model()`**: Resolves model strings with transparent `ollama:` prefix handling (defaults to `http://127.0.0.1:11434/v1` when `OLLAMA_BASE_URL` is unset)
-- **`run_script` tool**: Skill sub-agents can execute scripts from the skill's `scripts/` directory via a `run_script` tool, supporting `.py`, `.sh`, and generic executables with path validation
+- **`run_script` tool**: Skill sub-agents can execute scripts from the skill's `scripts/` directory via a `run_script` tool, supporting `.py`, `.sh`, `.js`, `.ts`, and generic executables with path validation
+- **JS/TS script support**: `run_script` dispatches `.js` files via `node` and `.ts` files via `npx tsx`; extensible via `SCRIPT_RUNNERS` mapping
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This sub-agent architecture means each skill runs in isolation with its own syst
 - **In-process tools** — Attach pydantic-ai `Tool` functions or `AbstractToolset` instances to skills
 - **Per-skill state** — Skills declare a Pydantic state model and namespace; state is passed to tools via `RunContext` and tracked on the toolset
 - **AG-UI protocol** — State changes emit `StateDeltaEvent` (JSON Patch), compatible with the [AG-UI protocol](https://docs.ag-ui.com)
-- **Script tools** — Python scripts in `scripts/` with a `main()` function, AST-parsed for typed tool schemas, executed via `uv run` with [PEP 723](https://peps.python.org/pep-0723/) dependency support
+- **Script tools** — Python, JavaScript, TypeScript, and shell scripts in `scripts/`; Python scripts with a `main()` function are AST-parsed for typed tool schemas and executed via `uv run` with [PEP 723](https://peps.python.org/pep-0723/) dependency support
 - **MCP integration** — Wrap any MCP server (stdio, SSE, streamable HTTP) as a skill
 
 ## Quick start

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ This sub-agent architecture means each skill runs in isolation with its own syst
 - **In-process tools** — Attach pydantic-ai `Tool` functions or `AbstractToolset` instances to skills
 - **Per-skill state** — Skills declare a Pydantic state model and namespace; state is passed to tools via `RunContext` and tracked on the toolset
 - **AG-UI protocol** — State changes emit `StateDeltaEvent` (JSON Patch), compatible with the [AG-UI protocol](https://docs.ag-ui.com)
-- **Script tools** — Python scripts in `scripts/` with a `main()` function, AST-parsed for typed tool schemas, executed via `uv run` with [PEP 723](https://peps.python.org/pep-0723/) dependency support
+- **Script tools** — Python, JavaScript, TypeScript, and shell scripts in `scripts/`; Python scripts with a `main()` function are AST-parsed for typed tool schemas and executed via `uv run` with [PEP 723](https://peps.python.org/pep-0723/) dependency support
 - **MCP integration** — Wrap any MCP server (stdio, SSE, streamable HTTP) as a skill
 
 ## Quick install

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -60,7 +60,7 @@ For `AbstractToolset` instances (e.g. MCP toolsets), use the `toolsets` paramete
 
 ## Script tools
 
-Skills can include executable Python scripts in a `scripts/` directory. Scripts must define a `main()` function with type-annotated parameters:
+Skills can include executable scripts in a `scripts/` directory. Python scripts that define a `main()` function with type-annotated parameters get AST-parsed into typed tools:
 
 ```python
 # /// script
@@ -91,7 +91,7 @@ if __name__ == "__main__":
 
 Script tools are automatically discovered on skill loading. Scripts with a `main()` function get AST-parsed into typed pydantic-ai `Tool` objects with automatic parameter schema extraction. Scripts without `main()` are skipped (with a warning) during typed tool discovery.
 
-Additionally, when a skill has a `scripts/` directory, the sub-agent receives a `run_script` tool that can execute any script (`.py`, `.sh`, or generic executable) with free-form arguments. This allows the LLM to invoke scripts that don't follow the `main()` convention.
+Additionally, when a skill has a `scripts/` directory, the sub-agent receives a `run_script` tool that can execute any script (`.py`, `.sh`, `.js`, `.ts`, or generic executable) with free-form arguments. This allows the LLM to invoke scripts that don't follow the `main()` convention.
 
 Typed script tools are executed via `uv run`, so [PEP 723](https://peps.python.org/pep-0723/) inline dependency metadata (the `# /// script` block above) is supported — dependencies are installed automatically.
 
@@ -103,6 +103,8 @@ The `run_script` tool expects a relative path under `scripts/` (e.g. `scripts/ex
 |-----------|----------|
 | `.py`     | Current Python interpreter (`sys.executable`) |
 | `.sh`     | `bash` |
+| `.js`     | `node` |
+| `.ts`     | `npx tsx` |
 | Other     | Run as executable directly |
 
 Both typed script tools and `run_script` prepend the skill directory to `PYTHONPATH`, so scripts can use package-style sibling imports:


### PR DESCRIPTION
- Introduce SCRIPT_RUNNERS mapping for extensible dispatch of script files by extension (.py, .sh, .js, .ts)
- .js files dispatched via node, .ts files via npx tsx
- Script listing in prompts now includes any file with a known runner or executable permission
- Custom runners can be added at runtime by modifying the SCRIPT_RUNNERS dict
