### PR TITLE
Manual skills take priority over entrypoint-discovered skills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Entrypoint skill priority**: Skills passed via `skills=` now take priority over entrypoint-discovered skills — entrypoints with the same name are silently skipped instead of raising a duplicate error
+
 ## [0.5.0] - 2026-02-25
 
 ### Added

--- a/docs/skill-sources.md
+++ b/docs/skill-sources.md
@@ -81,6 +81,20 @@ haiku-skills list --use-entrypoints
 haiku-skills chat --use-entrypoints -m openai:gpt-4o
 ```
 
+### Priority
+
+Skills passed via `skills=` take priority over entrypoint-discovered skills. If a manually provided skill has the same name as an entrypoint skill, the entrypoint is silently skipped. This lets you override an entrypoint skill with a custom configuration:
+
+```python
+from haiku.skills import SkillToolset
+
+custom_skill = create_my_skill(db_path="/custom/path")
+toolset = SkillToolset(
+    skills=[custom_skill],
+    use_entrypoints=True,  # entrypoint for "my-skill" is skipped
+)
+```
+
 ## MCP
 
 Any [MCP](https://modelcontextprotocol.io/) server can be wrapped as a skill using `skill_from_mcp`.

--- a/haiku/skills/agent.py
+++ b/haiku/skills/agent.py
@@ -193,6 +193,9 @@ class SkillToolset(FunctionToolset[Any]):
         self._namespaces: dict[str, BaseModel] = {}
         self._last_restored_state: dict[str, Any] | None = None
         self._skill_model = skill_model
+        if skills:
+            for skill in skills:
+                self._registry.register(skill)
         if skill_paths:
             self._registry.discover(paths=skill_paths)
         if use_entrypoints:
@@ -200,10 +203,6 @@ class SkillToolset(FunctionToolset[Any]):
         for name in self._registry.names:
             skill = self._registry.get(name)
             if skill:
-                self._register_skill_state(skill)
-        if skills:
-            for skill in skills:
-                self._registry.register(skill)
                 self._register_skill_state(skill)
         self._register_tools()
 

--- a/haiku/skills/registry.py
+++ b/haiku/skills/registry.py
@@ -39,4 +39,5 @@ class SkillRegistry:
                 self.register(skill)
         if use_entrypoints:
             for skill in discover_from_entrypoints():
-                self.register(skill)
+                if skill.metadata.name not in self._skills:
+                    self.register(skill)


### PR DESCRIPTION
Register skills passed via `skills=` before running entrypoint discovery. Entrypoint discovery now silently skips skills whose name is already registered, so manually provided skills always win. Filesystem path discovery still raises on duplicates.