### PR TITLE
Accept space-separated string for SkillMetadata.allowed_tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **Graphiti memory skill** (`haiku-skills-graphiti-memory`): Store, recall, and forget memories using a knowledge graph powered by [Graphiti](https://github.com/getzep/graphiti) and [FalkorDB](https://www.falkordb.com/) — with per-skill state tracking
 
+### Changed
+
+- **`SkillMetadata.allowed_tools` accepts strings**: Now accepts both `str` (space-separated) and `list[str]` as input, always stores `list[str]` — eliminates conversion overhead for consumers using the spec's string format ([#19](https://github.com/ggozad/haiku.skills/issues/19))
+
 ### Fixed
 
 - **Ollama base URL handling**: `resolve_model()` now appends `/v1` to `OLLAMA_BASE_URL` instead of expecting it in the env var, consistent with Ollama's convention

--- a/haiku/skills/models.py
+++ b/haiku/skills/models.py
@@ -39,6 +39,13 @@ class SkillMetadata(BaseModel):
     def validate_name(cls, v: str) -> str:
         return _validate_skill_name(v)
 
+    @field_validator("allowed_tools", mode="before")
+    @classmethod
+    def validate_allowed_tools(cls, v: str | list[str]) -> list[str]:
+        if isinstance(v, str):
+            return v.split() if v.strip() else []
+        return v
+
 
 class SkillSource(StrEnum):
     FILESYSTEM = "filesystem"

--- a/haiku/skills/parser.py
+++ b/haiku/skills/parser.py
@@ -25,13 +25,7 @@ def parse_skill_md(path: Path) -> tuple[SkillMetadata, str]:
     if "description" not in frontmatter:
         raise ValueError(f"SKILL.md at {path} is missing required field: description")
 
-    allowed_tools_raw = frontmatter.pop("allowed-tools", None)
-    if isinstance(allowed_tools_raw, list):
-        allowed_tools = allowed_tools_raw
-    elif allowed_tools_raw:
-        allowed_tools = allowed_tools_raw.split()
-    else:
-        allowed_tools = []
+    allowed_tools = frontmatter.pop("allowed-tools", [])
 
     metadata = SkillMetadata(
         allowed_tools=allowed_tools,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -79,6 +79,36 @@ class TestSkillMetadata:
         with pytest.raises(ValidationError):
             SkillMetadata(name="ok", description="x" * 1025)
 
+    def test_allowed_tools_from_string(self):
+        meta = SkillMetadata(
+            name="test",
+            description="Test.",
+            allowed_tools="Read Write",  # type: ignore[arg-type]
+        )
+        assert meta.allowed_tools == ["Read", "Write"]
+
+    def test_allowed_tools_from_empty_string(self):
+        meta = SkillMetadata(
+            name="test",
+            description="Test.",
+            allowed_tools="",  # type: ignore[arg-type]
+        )
+        assert meta.allowed_tools == []
+
+    def test_allowed_tools_from_whitespace_string(self):
+        meta = SkillMetadata(
+            name="test",
+            description="Test.",
+            allowed_tools="  ",  # type: ignore[arg-type]
+        )
+        assert meta.allowed_tools == []
+
+    def test_allowed_tools_from_list(self):
+        meta = SkillMetadata(
+            name="test", description="Test.", allowed_tools=["Read", "Write"]
+        )
+        assert meta.allowed_tools == ["Read", "Write"]
+
     def test_unknown_field_rejected(self):
         with pytest.raises(ValidationError, match="extra_field"):
             SkillMetadata(


### PR DESCRIPTION

- **`SkillMetadata.allowed_tools` accepts strings**: Now accepts both `str` (space-separated) and `list[str]` as input, always stores `list[str]` — eliminates conversion overhead for consumers using the spec's string format ([#19](https://github.com/ggozad/haiku.skills/issues/19))