### PR TITLE
Accept Model instances in Skill.model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - **`SkillMetadata.allowed_tools` accepts strings**: Now accepts both `str` (space-separated) and `list[str]` as input, always stores `list[str]` — eliminates conversion overhead for consumers using the spec's string format ([#19](https://github.com/ggozad/haiku.skills/issues/19))
+- **`Skill.model` accepts `Model` instances**: Widened from `str | None` to `str | Model | None` so consumers can pass configured model objects directly ([#20](https://github.com/ggozad/haiku.skills/issues/20))
 
 ### Fixed
 

--- a/haiku/skills/models.py
+++ b/haiku/skills/models.py
@@ -6,6 +6,7 @@ from typing import Annotated, Any
 
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator
 from pydantic_ai import Tool
+from pydantic_ai.models import Model
 from pydantic_ai.toolsets import AbstractToolset
 
 
@@ -61,7 +62,7 @@ class Skill(BaseModel):
     path: Path | None = None
     instructions: str | None = None
     resources: list[str] = Field(default_factory=list)
-    model: str | None = None
+    model: str | Model | None = None
     _tools: list[Tool | Callable[..., Any]] = PrivateAttr(default_factory=list)
     _toolsets: list[AbstractToolset[Any]] = PrivateAttr(default_factory=list)
     _state_type: type[BaseModel] | None = PrivateAttr(default=None)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -356,6 +356,23 @@ class TestAgent:
         result = await agent.run("Do something.")
         assert result.output
 
+    async def test_skill_model_instance_on_skill(self, allow_model_requests: None):
+        """A Model instance on skill.model flows through to the sub-agent."""
+        skill = Skill(
+            metadata=SkillMetadata(name="a", description="Test skill."),
+            source=SkillSource.ENTRYPOINT,
+            instructions="Do things.",
+            model=TestModel(),
+        )
+        toolset = SkillToolset(skills=[skill])
+        agent = Agent(
+            TestModel(),
+            instructions=build_system_prompt(toolset.skill_catalog),
+            toolsets=[toolset],
+        )
+        result = await agent.run("Do something.")
+        assert result.output
+
     async def test_skill_model_param_used_as_fallback(self, allow_model_requests: None):
         """skill_model param is used when skill has no model and env var unset."""
         skill = Skill(

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -234,6 +234,14 @@ class TestSkill:
         assert skill.state_type is MyState
         assert skill.state_namespace == "ns"
 
+    def test_with_model_instance(self):
+        from pydantic_ai.models.test import TestModel
+
+        meta = SkillMetadata(name="test", description="Test skill.")
+        model = TestModel()
+        skill = Skill(metadata=meta, source=SkillSource.FILESYSTEM, model=model)
+        assert skill.model is model
+
     def test_state_excluded_from_serialization(self):
         class MyState(BaseModel):
             value: int = 0


### PR DESCRIPTION
**`Skill.model` accepts `Model` instances**: Widened from `str | None` to `str | Model | None` so consumers can pass configured model objects directly ([#20](https://github.com/ggozad/haiku.skills/issues/20))

Closes #20 