### PR TITLE
Support single-skill-directory paths in discover_from_paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - **`SkillMetadata.allowed_tools` accepts strings**: Now accepts both `str` (space-separated) and `list[str]` as input, always stores `list[str]` — eliminates conversion overhead for consumers using the spec's string format ([#19](https://github.com/ggozad/haiku.skills/issues/19))
 - **`Skill.model` accepts `Model` instances**: Widened from `str | None` to `str | Model | None` so consumers can pass configured model objects directly ([#20](https://github.com/ggozad/haiku.skills/issues/20))
+- **`discover_from_paths` accepts single-skill directories**: Paths that contain `SKILL.md` directly are now treated as skill directories, in addition to parent directories containing skill subdirectories. Dot-directories are skipped during child iteration.
 
 ### Fixed
 

--- a/docs/skill-sources.md
+++ b/docs/skill-sources.md
@@ -31,7 +31,7 @@ from haiku.skills import SkillToolset
 toolset = SkillToolset(skill_paths=[Path("./skills")])
 ```
 
-If you point to a parent directory, all immediate subdirectories containing a `SKILL.md` are discovered. The directory name is used as the skill name (unless overridden in the frontmatter).
+Each path can be either a **parent directory** (all immediate subdirectories containing `SKILL.md` are discovered) or a **skill directory itself** (a directory that directly contains `SKILL.md`). The directory name must match the skill name in the frontmatter.
 
 Filesystem skills automatically pick up:
 


### PR DESCRIPTION
**`discover_from_paths` accepts single-skill directories**: Paths that contain `SKILL.md` directly are now treated as skill directories, in addition to parent directories containing skill subdirectories. Dot-directories are skipped during child iteration.