### PR TITLE
Collect all validation errors in discover_from_paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **`discover_from_paths` collects all validation errors**: Returns `tuple[list[Skill], list[SkillValidationError]]` instead of raising on the first broken skill — valid skills are still loaded while errors are collected ([#25](https://github.com/ggozad/haiku.skills/issues/25))
+- **`SkillRegistry.discover` returns errors**: Returns `list[SkillValidationError]` instead of `None`, propagating errors from `discover_from_paths`
+- **CLI prints discovery warnings**: `list` and `chat` commands print validation errors as warnings to stderr instead of aborting
+
+### Added
+
+- **`SkillValidationError`**: `ValueError` subclass with a `.path` attribute, exported from `haiku.skills`
+
 ## [0.6.0] - 2026-03-03
 
 ### Added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -27,6 +27,8 @@ haiku-skills list --use-entrypoints
 haiku-skills list -s ./skills --use-entrypoints
 ```
 
+If any skill directories have validation errors, they are printed as warnings to stderr while valid skills are still listed.
+
 ## `chat`
 
 A debug/development chat TUI built with [Textual](https://textual.textualize.io/). Requires the `tui` extra:

--- a/docs/skill-sources.md
+++ b/docs/skill-sources.md
@@ -33,6 +33,8 @@ toolset = SkillToolset(skill_paths=[Path("./skills")])
 
 Each path can be either a **parent directory** (all immediate subdirectories containing `SKILL.md` are discovered) or a **skill directory itself** (a directory that directly contains `SKILL.md`). The directory name must match the skill name in the frontmatter.
 
+When a skill directory has validation errors (bad frontmatter, name mismatch, etc.), the error is collected as a `SkillValidationError` and discovery continues with the remaining directories. Non-existent paths are also collected as errors rather than aborting. The CLI commands print these errors as warnings to stderr.
+
 Filesystem skills automatically pick up:
 
 - **Script tools** — Python scripts in a `scripts/` subdirectory (see [Skills — Script tools](skills.md#script-tools))

--- a/haiku/skills/__init__.py
+++ b/haiku/skills/__init__.py
@@ -9,6 +9,7 @@ from haiku.skills.models import (
     Skill,
     SkillMetadata,
     SkillSource,
+    SkillValidationError,
 )
 from haiku.skills.prompts import build_system_prompt
 from haiku.skills.registry import SkillRegistry

--- a/haiku/skills/cli.py
+++ b/haiku/skills/cli.py
@@ -30,7 +30,9 @@ def _resolve_discovery(
         ).lower() in ("1", "true", "yes")
 
     registry = SkillRegistry()
-    registry.discover(paths=paths or None, use_entrypoints=use_entrypoints)
+    errors = registry.discover(paths=paths or None, use_entrypoints=use_entrypoints)
+    for error in errors:
+        typer.echo(f"Warning: {error.path}: {error}", err=True)
     return registry
 
 

--- a/haiku/skills/discovery.py
+++ b/haiku/skills/discovery.py
@@ -1,7 +1,9 @@
 from importlib.metadata import entry_points
 from pathlib import Path
 
-from haiku.skills.models import Skill, SkillSource
+from pydantic import ValidationError
+
+from haiku.skills.models import Skill, SkillSource, SkillValidationError
 from haiku.skills.parser import parse_skill_md
 from haiku.skills.script_tools import discover_script_tools
 
@@ -25,22 +27,35 @@ def _load_skill_from_directory(skill_dir: Path) -> Skill:
     )
 
 
-def discover_from_paths(paths: list[Path]) -> list[Skill]:
+def discover_from_paths(
+    paths: list[Path],
+) -> tuple[list[Skill], list[SkillValidationError]]:
     """Scan directories for subdirectories containing SKILL.md."""
     skills: list[Skill] = []
+    errors: list[SkillValidationError] = []
+
+    def _try_load(skill_dir: Path) -> None:
+        try:
+            skills.append(_load_skill_from_directory(skill_dir))
+        except (ValueError, ValidationError) as exc:
+            errors.append(SkillValidationError(str(exc), skill_dir))
+
     for path in paths:
         if not path.exists():
-            raise FileNotFoundError(f"Skill path does not exist: {path}")
+            errors.append(
+                SkillValidationError(f"Skill path does not exist: {path}", path)
+            )
+            continue
         if (path / "SKILL.md").exists():
-            skills.append(_load_skill_from_directory(path))
+            _try_load(path)
             continue
         for child in sorted(path.iterdir()):
             if child.name.startswith("."):
                 continue
             if not child.is_dir() or not (child / "SKILL.md").exists():
                 continue
-            skills.append(_load_skill_from_directory(child))
-    return skills
+            _try_load(child)
+    return skills, errors
 
 
 def discover_resources(skill_path: Path) -> list[str]:

--- a/haiku/skills/models.py
+++ b/haiku/skills/models.py
@@ -10,6 +10,14 @@ from pydantic_ai.models import Model
 from pydantic_ai.toolsets import AbstractToolset
 
 
+class SkillValidationError(ValueError):
+    """A validation error associated with a specific skill path."""
+
+    def __init__(self, message: str, path: Path):
+        self.path = path
+        super().__init__(message)
+
+
 def _validate_skill_name(name: str) -> str:
     name = unicodedata.normalize("NFKC", name)
     if name != name.lower():

--- a/haiku/skills/registry.py
+++ b/haiku/skills/registry.py
@@ -4,7 +4,7 @@ from haiku.skills.discovery import (
     discover_from_entrypoints,
     discover_from_paths,
 )
-from haiku.skills.models import Skill, SkillMetadata
+from haiku.skills.models import Skill, SkillMetadata, SkillValidationError
 
 
 class SkillRegistry:
@@ -33,11 +33,15 @@ class SkillRegistry:
         self,
         paths: list[Path] | None = None,
         use_entrypoints: bool = False,
-    ) -> None:
+    ) -> list[SkillValidationError]:
+        errors: list[SkillValidationError] = []
         if paths:
-            for skill in discover_from_paths(paths):
+            skills, path_errors = discover_from_paths(paths)
+            errors.extend(path_errors)
+            for skill in skills:
                 self.register(skill)
         if use_entrypoints:
             for skill in discover_from_entrypoints():
                 if skill.metadata.name not in self._skills:
                     self.register(skill)
+        return errors

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -8,40 +8,44 @@ from haiku.skills.discovery import (
     discover_from_paths,
     discover_resources,
 )
-from haiku.skills.models import Skill, SkillMetadata, SkillSource
+from haiku.skills.models import Skill, SkillMetadata, SkillSource, SkillValidationError
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
 
 class TestDiscoverFromPaths:
     def test_discovers_skills_in_directory(self):
-        skills = discover_from_paths([FIXTURES])
+        skills, errors = discover_from_paths([FIXTURES])
         names = {s.metadata.name for s in skills}
         assert "simple-skill" in names
         assert "skill-with-refs" in names
+        assert errors == []
 
     def test_returns_filesystem_source(self):
-        skills = discover_from_paths([FIXTURES])
+        skills, errors = discover_from_paths([FIXTURES])
         for skill in skills:
             assert skill.source == SkillSource.FILESYSTEM
+        assert errors == []
 
     def test_sets_path_to_skill_directory(self):
-        skills = discover_from_paths([FIXTURES])
+        skills, errors = discover_from_paths([FIXTURES])
         by_name = {s.metadata.name: s for s in skills}
         assert by_name["simple-skill"].path == FIXTURES / "simple-skill"
+        assert errors == []
 
     def test_instructions_loaded(self):
-        skills = discover_from_paths([FIXTURES])
+        skills, errors = discover_from_paths([FIXTURES])
         for skill in skills:
             assert skill.instructions is not None
+        assert errors == []
 
     def test_script_tools_loaded(self):
-        skills = discover_from_paths([FIXTURES])
+        skills, errors = discover_from_paths([FIXTURES])
         by_name = {s.metadata.name: s for s in skills}
         assert len(by_name["simple-skill"].tools) == 1
 
     def test_resources_loaded(self):
-        skills = discover_from_paths([FIXTURES])
+        skills, errors = discover_from_paths([FIXTURES])
         by_name = {s.metadata.name: s for s in skills}
         assert "references/REFERENCE.md" in by_name["skill-with-refs"].resources
         assert "assets/template.txt" in by_name["skill-with-refs"].resources
@@ -52,20 +56,28 @@ class TestDiscoverFromPaths:
         (skill_dir / "SKILL.md").write_text(
             "---\nname: wrong-name\ndescription: Mismatch.\n---\nBody.\n"
         )
-        with pytest.raises(ValueError, match="does not match"):
-            discover_from_paths([tmp_path])
+        skills, errors = discover_from_paths([tmp_path])
+        assert skills == []
+        assert len(errors) == 1
+        assert "does not match" in str(errors[0])
+        assert errors[0].path == skill_dir
 
     def test_skips_non_skill_entries(self, tmp_path: Path):
         # A file (not a directory) should be skipped
         (tmp_path / "readme.txt").write_text("not a skill")
         # A directory without SKILL.md should be skipped
         (tmp_path / "not-a-skill").mkdir()
-        skills = discover_from_paths([tmp_path])
+        skills, errors = discover_from_paths([tmp_path])
         assert skills == []
+        assert errors == []
 
-    def test_nonexistent_path_raises(self):
-        with pytest.raises(FileNotFoundError):
-            discover_from_paths([Path("/nonexistent/path")])
+    def test_nonexistent_path_returns_error(self):
+        bad_path = Path("/nonexistent/path")
+        skills, errors = discover_from_paths([bad_path])
+        assert skills == []
+        assert len(errors) == 1
+        assert isinstance(errors[0], SkillValidationError)
+        assert errors[0].path == bad_path
 
     def test_path_is_skill_directory(self, tmp_path: Path):
         skill_dir = tmp_path / "my-skill"
@@ -73,10 +85,11 @@ class TestDiscoverFromPaths:
         (skill_dir / "SKILL.md").write_text(
             "---\nname: my-skill\ndescription: A skill.\n---\nBody.\n"
         )
-        skills = discover_from_paths([skill_dir])
+        skills, errors = discover_from_paths([skill_dir])
         assert len(skills) == 1
         assert skills[0].metadata.name == "my-skill"
         assert skills[0].path == skill_dir
+        assert errors == []
 
     def test_skips_dot_directories(self, tmp_path: Path):
         dot_dir = tmp_path / ".hidden-skill"
@@ -89,10 +102,11 @@ class TestDiscoverFromPaths:
         (visible_dir / "SKILL.md").write_text(
             "---\nname: visible-skill\ndescription: Visible.\n---\nBody.\n"
         )
-        skills = discover_from_paths([tmp_path])
+        skills, errors = discover_from_paths([tmp_path])
         names = {s.metadata.name for s in skills}
         assert "visible-skill" in names
         assert "hidden-skill" not in names
+        assert errors == []
 
     def test_multiple_paths(self, tmp_path: Path):
         dir_a = tmp_path / "a"
@@ -111,9 +125,48 @@ class TestDiscoverFromPaths:
             "---\nname: skill-b\ndescription: Skill B.\n---\nBody B.\n"
         )
 
-        skills = discover_from_paths([dir_a, dir_b])
+        skills, errors = discover_from_paths([dir_a, dir_b])
         names = {s.metadata.name for s in skills}
         assert names == {"skill-a", "skill-b"}
+        assert errors == []
+
+    def test_collects_multiple_errors(self, tmp_path: Path):
+        # Two broken skills and one valid
+        valid = tmp_path / "valid-skill"
+        valid.mkdir()
+        (valid / "SKILL.md").write_text(
+            "---\nname: valid-skill\ndescription: Good.\n---\nBody.\n"
+        )
+
+        bad1 = tmp_path / "bad-one"
+        bad1.mkdir()
+        (bad1 / "SKILL.md").write_text(
+            "---\nname: wrong-name\ndescription: Mismatch.\n---\nBody.\n"
+        )
+
+        bad2 = tmp_path / "bad-two"
+        bad2.mkdir()
+        (bad2 / "SKILL.md").write_text(
+            "---\nname: also-wrong\ndescription: Mismatch.\n---\nBody.\n"
+        )
+
+        skills, errors = discover_from_paths([tmp_path])
+        assert len(skills) == 1
+        assert skills[0].metadata.name == "valid-skill"
+        assert len(errors) == 2
+        error_paths = {e.path for e in errors}
+        assert error_paths == {bad1, bad2}
+
+    def test_pydantic_validation_error_collected(self, tmp_path: Path):
+        skill_dir = tmp_path / "bad-skill"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: BAD-SKILL\ndescription: Invalid name.\n---\nBody.\n"
+        )
+        skills, errors = discover_from_paths([tmp_path])
+        assert skills == []
+        assert len(errors) == 1
+        assert errors[0].path == skill_dir
 
 
 class TestDiscoverResources:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -8,7 +8,23 @@ from haiku.skills.models import (
     Skill,
     SkillMetadata,
     SkillSource,
+    SkillValidationError,
 )
+
+
+class TestSkillValidationError:
+    def test_is_value_error(self):
+        err = SkillValidationError("something went wrong", Path("/skills/broken"))
+        assert isinstance(err, ValueError)
+
+    def test_stores_path(self):
+        p = Path("/skills/broken")
+        err = SkillValidationError("bad", p)
+        assert err.path is p
+
+    def test_str_returns_message(self):
+        err = SkillValidationError("something went wrong", Path("/skills/broken"))
+        assert str(err) == "something went wrong"
 
 
 class TestSkillMetadata:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 import pytest
 
-from haiku.skills.models import Skill, SkillMetadata, SkillSource
+from haiku.skills.models import Skill, SkillMetadata, SkillSource, SkillValidationError
 from haiku.skills.registry import SkillRegistry
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -57,34 +57,38 @@ class TestSkillRegistry:
 
     def test_discover_from_paths(self):
         registry = SkillRegistry()
-        registry.discover(paths=[FIXTURES])
+        errors = registry.discover(paths=[FIXTURES])
         assert "simple-skill" in registry.names
         assert "skill-with-refs" in registry.names
+        assert errors == []
 
     def test_discover_loads_instructions(self):
         registry = SkillRegistry()
-        registry.discover(paths=[FIXTURES])
+        errors = registry.discover(paths=[FIXTURES])
         skill = registry.get("simple-skill")
         assert skill is not None
         assert skill.instructions is not None
         assert "# Simple Skill" in skill.instructions
+        assert errors == []
 
     def test_discover_loads_script_tools(self):
         registry = SkillRegistry()
-        registry.discover(paths=[FIXTURES])
+        errors = registry.discover(paths=[FIXTURES])
         skill = registry.get("simple-skill")
         assert skill is not None
         assert len(skill.tools) == 1
         tool = skill.tools[0]
         assert hasattr(tool, "name") and tool.name == "greet"
+        assert errors == []
 
     def test_discover_loads_resources(self):
         registry = SkillRegistry()
-        registry.discover(paths=[FIXTURES])
+        errors = registry.discover(paths=[FIXTURES])
         skill = registry.get("skill-with-refs")
         assert skill is not None
         assert "references/REFERENCE.md" in skill.resources
         assert "assets/template.txt" in skill.resources
+        assert errors == []
 
     def test_discover_from_entrypoints(self, monkeypatch: pytest.MonkeyPatch):
         skill = _make_skill("ep-skill", source=SkillSource.ENTRYPOINT)
@@ -94,8 +98,9 @@ class TestSkillRegistry:
             lambda group: [mock_ep],
         )
         registry = SkillRegistry()
-        registry.discover(use_entrypoints=True)
+        errors = registry.discover(use_entrypoints=True)
         assert "ep-skill" in registry.names
+        assert errors == []
 
     def test_entrypoint_skips_already_registered(self, monkeypatch: pytest.MonkeyPatch):
         ep_skill = _make_skill("overlap", source=SkillSource.ENTRYPOINT)
@@ -109,5 +114,24 @@ class TestSkillRegistry:
         )
         registry = SkillRegistry()
         registry.register(manual_skill)
-        registry.discover(use_entrypoints=True)
+        errors = registry.discover(use_entrypoints=True)
         assert registry.get("overlap") is manual_skill
+        assert errors == []
+
+    def test_discover_returns_errors(self, tmp_path: Path):
+        valid = tmp_path / "good-skill"
+        valid.mkdir()
+        (valid / "SKILL.md").write_text(
+            "---\nname: good-skill\ndescription: Good.\n---\nBody.\n"
+        )
+        broken = tmp_path / "broken-skill"
+        broken.mkdir()
+        (broken / "SKILL.md").write_text(
+            "---\nname: wrong-name\ndescription: Broken.\n---\nBody.\n"
+        )
+        registry = SkillRegistry()
+        errors = registry.discover(paths=[tmp_path])
+        assert "good-skill" in registry.names
+        assert len(errors) == 1
+        assert isinstance(errors[0], SkillValidationError)
+        assert errors[0].path == broken


### PR DESCRIPTION

### Changed

- **`discover_from_paths` collects all validation errors**: Returns `tuple[list[Skill], list[SkillValidationError]]` instead of raising on the first broken skill — valid skills are still loaded while errors are collected ([#25](https://github.com/ggozad/haiku.skills/issues/25))
- **`SkillRegistry.discover` returns errors**: Returns `list[SkillValidationError]` instead of `None`, propagating errors from `discover_from_paths`
- **CLI prints discovery warnings**: `list` and `chat` commands print validation errors as warnings to stderr instead of aborting

### Added

- **`SkillValidationError`**: `ValueError` subclass with a `.path` attribute, exported from `haiku.skills`


Closes #25 