### PR TITLE
Add StateMetadata dataclass and state_metadata() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
 ### Added
 
 - **`SkillValidationError`**: `ValueError` subclass with a `.path` attribute, exported from `haiku.skills`
+- **`StateMetadata`**: Frozen dataclass with `namespace`, `type`, and `schema` fields, exported from `haiku.skills`
+- **`Skill.state_metadata()`**: Returns a `StateMetadata` for skills that declare state; `None` otherwise
 
 ## [0.6.0] - 2026-03-03
 

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -161,3 +161,14 @@ print(toolset.build_state_snapshot())  # {"calculator": {"history": []}}
 ```
 
 When `execute_skill` runs a skill whose tools modify state, the toolset computes a JSON Patch delta and returns it as a `StateDeltaEvent` — compatible with the [AG-UI protocol](https://docs.ag-ui.com). See [AG-UI protocol](ag-ui.md) for details.
+
+### Introspecting state
+
+Use `state_metadata()` to inspect a skill's state configuration without running it:
+
+```python
+meta = skill.state_metadata()
+# StateMetadata(namespace="calculator", type=<class 'CalculatorState'>, schema={...})
+```
+
+Returns `None` for skills without state. The `schema` attribute contains the JSON Schema from `model_json_schema()`.

--- a/haiku/skills/__init__.py
+++ b/haiku/skills/__init__.py
@@ -10,6 +10,7 @@ from haiku.skills.models import (
     SkillMetadata,
     SkillSource,
     SkillValidationError,
+    StateMetadata,
 )
 from haiku.skills.prompts import build_system_prompt
 from haiku.skills.registry import SkillRegistry

--- a/haiku/skills/models.py
+++ b/haiku/skills/models.py
@@ -1,5 +1,6 @@
 import unicodedata
 from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
 from typing import Annotated, Any
@@ -8,6 +9,13 @@ from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_validator
 from pydantic_ai import Tool
 from pydantic_ai.models import Model
 from pydantic_ai.toolsets import AbstractToolset
+
+
+@dataclass(frozen=True)
+class StateMetadata:
+    namespace: str
+    type: type[BaseModel]
+    schema: dict[str, Any]
 
 
 class SkillValidationError(ValueError):
@@ -122,3 +130,12 @@ class Skill(BaseModel):
     @state_namespace.setter
     def state_namespace(self, value: str | None) -> None:
         self._state_namespace = value
+
+    def state_metadata(self) -> StateMetadata | None:
+        if self._state_type is None or self._state_namespace is None:
+            return None
+        return StateMetadata(
+            namespace=self._state_namespace,
+            type=self._state_type,
+            schema=self._state_type.model_json_schema(),
+        )

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -272,3 +272,46 @@ class TestSkill:
         data = skill.model_dump()
         assert "state_type" not in data
         assert "state_namespace" not in data
+
+    def test_state_metadata_with_state(self):
+        class MyState(BaseModel):
+            value: int = 0
+
+        meta = SkillMetadata(name="test", description="Test skill.")
+        skill = Skill(
+            metadata=meta,
+            source=SkillSource.FILESYSTEM,
+            state_type=MyState,
+            state_namespace="ns",
+        )
+        result = skill.state_metadata()
+        assert result is not None
+        assert result.namespace == "ns"
+        assert result.type is MyState
+        assert result.schema == MyState.model_json_schema()
+
+    def test_state_metadata_without_state(self):
+        meta = SkillMetadata(name="test", description="Test skill.")
+        skill = Skill(metadata=meta, source=SkillSource.FILESYSTEM)
+        assert skill.state_metadata() is None
+
+    def test_state_metadata_partial_type_without_namespace(self):
+        class MyState(BaseModel):
+            value: int = 0
+
+        meta = SkillMetadata(name="test", description="Test skill.")
+        skill = Skill(
+            metadata=meta,
+            source=SkillSource.FILESYSTEM,
+            state_type=MyState,
+        )
+        assert skill.state_metadata() is None
+
+    def test_state_metadata_partial_namespace_without_type(self):
+        meta = SkillMetadata(name="test", description="Test skill.")
+        skill = Skill(
+            metadata=meta,
+            source=SkillSource.FILESYSTEM,
+            state_namespace="ns",
+        )
+        assert skill.state_metadata() is None


### PR DESCRIPTION
- **`StateMetadata`**: Frozen dataclass with `namespace`, `type`, and `schema` fields, exported from `haiku.skills`
- **`Skill.state_metadata()`**: Returns a `StateMetadata` for skills that declare state; `None` otherwise
