### PR TITLE
move ag-ui-protocol and jsonpatch to core dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - **Skill package PyPI metadata**: All 4 skill packages now include authors, license, readme, keywords, classifiers, and project URLs
 - **Skill package READMEs**: `haiku-skills-web`, `haiku-skills-image-generation`, and `haiku-skills-code-execution` now have READMEs with prerequisites, configuration, tools, and installation instructions
 
+### Fixed
+
+- **Missing core dependencies**: `ag-ui-protocol` and `jsonpatch` moved from optional `[ag-ui]` extra to core dependencies — a clean install of `haiku.skills` no longer fails with `ModuleNotFoundError: No module named 'ag_ui'`
+
 ### Changed
 
 - **`generate_image` returns file path**: The image generation tool now returns the file path directly instead of a markdown image reference

--- a/docs/ag-ui.md
+++ b/docs/ag-ui.md
@@ -2,12 +2,6 @@
 
 haiku.skills supports the [AG-UI protocol](https://docs.ag-ui.com) for communicating state changes to frontend clients.
 
-## Installation
-
-```bash
-uv add "haiku.skills[ag-ui]"
-```
-
 ## Per-skill state
 
 Skills can declare a Pydantic state model and a namespace. State is passed to tool functions via `RunContext[SkillRunDeps]` and tracked per namespace on the `SkillToolset`.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -61,7 +61,7 @@ Set the model to use for skill sub-agents (overrides `HAIKU_SKILL_MODEL` env var
 haiku-skills chat -s ./skills -m openai:gpt-4o --skill-model ollama:llama3
 ```
 
-The `tui` extra includes `ag-ui-protocol`. The chat TUI uses the AG-UI protocol adapter for event streaming, making it useful for debugging skills with [per-skill state](skills.md#per-skill-state):
+The chat TUI uses the AG-UI protocol adapter for event streaming, making it useful for debugging skills with [per-skill state](skills.md#per-skill-state):
 
 - **State deltas** are displayed inline as JSON Patch operations whenever a skill modifies state
 - **Full state snapshot** is available via the "View state" modal in the command palette

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,14 +14,6 @@ pip install haiku.skills
 
 ## Extras
 
-### AG-UI protocol support
-
-For [AG-UI protocol](https://docs.ag-ui.com) compatibility (state deltas via JSON Patch):
-
-```bash
-uv add "haiku.skills[ag-ui]"
-```
-
 ### Chat TUI
 
 A debug/development chat interface built with [Textual](https://textual.textualize.io/):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,8 @@ classifiers = [
 ]
 
 dependencies = [
+    "ag-ui-protocol>=0.1.13",
+    "jsonpatch>=1.33",
     "pydantic>=2.12.5",
     "pydantic-ai-slim[mcp]>=1.63.0",
     "pyyaml>=6.0.3",
@@ -35,14 +37,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-ag-ui = [
-    "ag-ui-protocol>=0.1.13",
-    "jsonpatch>=1.33",
-]
 tui = [
     "pydantic-ai-slim[logfire]>=1.63.0",
-    "ag-ui-protocol>=0.1.13",
-    "jsonpatch>=1.33",
     "textual>=8.0.0",
     "typer>=0.24.1",
     "python-dotenv>=1.2.1",
@@ -83,8 +79,6 @@ dev = [
     "haiku-skills-image-generation",
     "haiku-skills-code-execution",
     "haiku-skills-graphiti-memory",
-    "ag-ui-protocol>=0.1.13",
-    "jsonpatch>=1.33",
     "mkdocs>=1.6.1,<2.0.0",
     "mkdocs-material>=9.7.3",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -501,6 +501,8 @@ name = "haiku-skills"
 version = "0.7.0"
 source = { editable = "." }
 dependencies = [
+    { name = "ag-ui-protocol" },
+    { name = "jsonpatch" },
     { name = "pydantic" },
     { name = "pydantic-ai-slim", extra = ["mcp"] },
     { name = "pyyaml" },
@@ -508,13 +510,7 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
-ag-ui = [
-    { name = "ag-ui-protocol" },
-    { name = "jsonpatch" },
-]
 tui = [
-    { name = "ag-ui-protocol" },
-    { name = "jsonpatch" },
     { name = "pydantic-ai-slim", extra = ["logfire"] },
     { name = "python-dotenv" },
     { name = "textual" },
@@ -523,12 +519,10 @@ tui = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "ag-ui-protocol" },
     { name = "haiku-skills-code-execution" },
     { name = "haiku-skills-graphiti-memory" },
     { name = "haiku-skills-image-generation" },
     { name = "haiku-skills-web" },
-    { name = "jsonpatch" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
     { name = "pre-commit" },
@@ -547,10 +541,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "ag-ui-protocol", marker = "extra == 'ag-ui'", specifier = ">=0.1.13" },
-    { name = "ag-ui-protocol", marker = "extra == 'tui'", specifier = ">=0.1.13" },
-    { name = "jsonpatch", marker = "extra == 'ag-ui'", specifier = ">=1.33" },
-    { name = "jsonpatch", marker = "extra == 'tui'", specifier = ">=1.33" },
+    { name = "ag-ui-protocol", specifier = ">=0.1.13" },
+    { name = "jsonpatch", specifier = ">=1.33" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "pydantic-ai-slim", extras = ["logfire"], marker = "extra == 'tui'", specifier = ">=1.63.0" },
     { name = "pydantic-ai-slim", extras = ["mcp"], specifier = ">=1.63.0" },
@@ -560,16 +552,14 @@ requires-dist = [
     { name = "textual", marker = "extra == 'tui'", specifier = ">=8.0.0" },
     { name = "typer", marker = "extra == 'tui'", specifier = ">=0.24.1" },
 ]
-provides-extras = ["ag-ui", "tui"]
+provides-extras = ["tui"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "ag-ui-protocol", specifier = ">=0.1.13" },
     { name = "haiku-skills-code-execution", editable = "skills/code-execution" },
     { name = "haiku-skills-graphiti-memory", editable = "skills/graphiti-memory" },
     { name = "haiku-skills-image-generation", editable = "skills/image-generation" },
     { name = "haiku-skills-web", editable = "skills/web" },
-    { name = "jsonpatch", specifier = ">=1.33" },
     { name = "mkdocs", specifier = ">=1.6.1,<2.0.0" },
     { name = "mkdocs-material", specifier = ">=9.7.3" },
     { name = "pre-commit", specifier = ">=4.5.1" },


### PR DESCRIPTION
- **Missing core dependencies**: `ag-ui-protocol` and `jsonpatch` moved from optional `[ag-ui]` extra to core dependencies — a clean install of `haiku.skills` no longer fails with `ModuleNotFoundError: No module named 'ag_ui'