### PR TITLE
Fix Skill.reconfigure() silently dropping instructions and resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`Skill.reconfigure()` now copies `instructions` and `resources`**: Previously, `reconfigure()` silently dropped `instructions` and `resources` from the factory-produced skill, causing factory-generated instructions (e.g. config-dependent preambles) to be lost after reconfiguration.
+
 ## [0.13.1] - 2026-04-07
 
 ### Fixed

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -100,7 +100,7 @@ agent = Agent(
 
 ## Reconfiguring entrypoint skills
 
-Entrypoint skills discovered via `SkillToolset(use_entrypoints=True)` store their factory function. Call `reconfigure(**kwargs)` to re-invoke the factory with new arguments, replacing tools, state, and model while preserving metadata. This is useful when a skill's factory accepts optional parameters (e.g. config, database path) that the entry point loader doesn't pass:
+Entrypoint skills discovered via `SkillToolset(use_entrypoints=True)` store their factory function. Call `reconfigure(**kwargs)` to re-invoke the factory with new arguments, replacing tools, state, model, instructions, and resources while preserving metadata. This is useful when a skill's factory accepts optional parameters (e.g. config, database path) that the entry point loader doesn't pass:
 
 ```python
 from haiku.skills import SkillToolset
@@ -110,7 +110,7 @@ skill = toolset.registry.get("my-rag-skill")
 skill.reconfigure(config=my_config, db_path=my_db_path)
 ```
 
-`reconfigure()` re-invokes the factory with the given keyword arguments and replaces the skill's tools, state, and model in place. Metadata, instructions, and source are preserved — the skill keeps its identity in the registry.
+`reconfigure()` re-invokes the factory with the given keyword arguments and replaces the skill's tools, state, model, instructions, and resources in place. Metadata, source, path, and verified status are preserved — the skill keeps its identity in the registry.
 
 This only works for entrypoint skills — filesystem and MCP skills have no factory and will raise `RuntimeError`.
 

--- a/haiku/skills/models.py
+++ b/haiku/skills/models.py
@@ -173,7 +173,8 @@ class Skill(BaseModel):
         """Re-create this skill with new factory arguments.
 
         Calls the stored factory with the given kwargs and copies all
-        private attributes and model from the result.
+        private attributes, model, instructions, and resources from
+        the result. Metadata, source, path, and verified are preserved.
         """
         if self._factory is None:
             raise RuntimeError("Skill has no factory — cannot reconfigure")
@@ -186,6 +187,8 @@ class Skill(BaseModel):
         self._thinking = new_skill._thinking
         self._deps_type = new_skill._deps_type
         self.model = new_skill.model
+        self.instructions = new_skill.instructions
+        self.resources = new_skill.resources
 
     def state_metadata(self) -> StateMetadata | None:
         if self._state_type is None or self._state_namespace is None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -511,7 +511,45 @@ class TestSkillReconfigure:
         assert skill.metadata.name == "test"
         assert skill.metadata.description == "Original description."
         assert skill.source == SkillSource.ENTRYPOINT
-        assert skill.instructions == "original instructions"
+        assert skill.instructions == "new instructions"
+
+    def test_reconfigure_replaces_instructions(self):
+        def factory(domain: str = "default") -> Skill:
+            return Skill(
+                metadata=SkillMetadata(name="test", description="Test."),
+                source=SkillSource.ENTRYPOINT,
+                instructions=f"You are a {domain} assistant.",
+            )
+
+        skill = Skill(
+            metadata=SkillMetadata(name="test", description="Test."),
+            source=SkillSource.ENTRYPOINT,
+            instructions="You are a default assistant.",
+        )
+        skill._factory = factory
+        assert skill.instructions == "You are a default assistant."
+
+        skill.reconfigure(domain="finance")
+        assert skill.instructions == "You are a finance assistant."
+
+    def test_reconfigure_replaces_resources(self):
+        def factory(lang: str = "en") -> Skill:
+            return Skill(
+                metadata=SkillMetadata(name="test", description="Test."),
+                source=SkillSource.ENTRYPOINT,
+                resources=[f"references/{lang}/REFERENCE.md"],
+            )
+
+        skill = Skill(
+            metadata=SkillMetadata(name="test", description="Test."),
+            source=SkillSource.ENTRYPOINT,
+            resources=["references/en/REFERENCE.md"],
+        )
+        skill._factory = factory
+        assert skill.resources == ["references/en/REFERENCE.md"]
+
+        skill.reconfigure(lang="fr")
+        assert skill.resources == ["references/fr/REFERENCE.md"]
 
     def test_thinking(self):
         meta = SkillMetadata(name="test", description="Test skill.")


### PR DESCRIPTION
- **`Skill.reconfigure()` now copies `instructions` and `resources`**: Previously, `reconfigure()` silently dropped `instructions` and `resources` from the factory-produced skill, causing factory-generated instructions (e.g. config-dependent preambles) to be lost after reconfiguration.