### PR TITLE
feat: add lifespan hook to Skill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`lifespan` on `Skill`**: Optional async context manager factory called once per skill invocation (one `_run_skill()` call, i.e. one sub-agent run). The factory receives the skill's `deps`; use it to set up and tear down per-invocation resources (e.g. a database client opened once and reused across tool calls, a counter scoped to the invocation). Pair with `deps_type=` to give tools typed access via `ctx.deps.<field>`. Strictly additive and opt-in — skills without a `lifespan` are unaffected. Not wired for direct-tool mode (`SkillToolset` with `use_subagents=False`) — that path has no well-defined invocation boundary.
+
 ## [0.14.0] - 2026-04-16
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - **`lifespan` on `Skill`**: Optional async context manager factory called once per skill invocation (one `_run_skill()` call, i.e. one sub-agent run). The factory receives the skill's `deps`; use it to set up and tear down per-invocation resources (e.g. a database client opened once and reused across tool calls, a counter scoped to the invocation). Pair with `deps_type=` to give tools typed access via `ctx.deps.<field>`. Strictly additive and opt-in — skills without a `lifespan` are unaffected. Not wired for direct-tool mode (`SkillToolset` with `use_subagents=False`) — that path has no well-defined invocation boundary.
 
+### Changed
+
+- **Bundled `code-execution` and `sandbox` skills migrated to `lifespan`**: `haiku-skills-code-execution` now uses a `MontyRepl` populated by a lifespan, so variables and definitions declared in one `run_code` call persist into subsequent `run_code` calls within the same sub-agent invocation. `haiku-skills-sandbox` replaces its `__post_init__` deps setup with a named `sandbox_lifespan`; session-scoped container persistence (via `SandboxState.session_id`) is unchanged.
+
 ## [0.14.0] - 2026-04-16
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Skills are discovered automatically and can come from three sources:
 
 - **Per-skill state**: Pydantic state models tracked per namespace; state deltas emitted as JSON Patch for the [AG-UI protocol](https://docs.ag-ui.com)
 - **AG-UI streaming**: skill tool calls and state changes stream as `ActivitySnapshotEvent` and `StateDeltaEvent` for real-time UIs
+- **Custom dependencies and lifespan**: declare a `deps_type` to extend what skill tools see on `ctx.deps`; optionally attach a `lifespan` async context manager to allocate per-invocation resources (DB clients, caches, counters) that are disposed when the skill run ends
 - **Signing and verification**: identity-based skill signing via [sigstore](https://www.sigstore.dev/), verified at discovery time
 - **CLI**: `haiku-skills list`, `validate`, `sign`, `verify`, and an interactive `chat` TUI
 

--- a/docs/custom-dependencies.md
+++ b/docs/custom-dependencies.md
@@ -1,0 +1,33 @@
+# Custom dependencies
+
+By default, skill sub-agents receive `SkillRunDeps` — a dataclass with `state` and `emit`. Skills that integrate external toolsets requiring additional context on the deps object can declare a `deps_type` — any class that satisfies `SkillRunDepsProtocol` (must have `state: BaseModel | None` and `emit: Callable`) and accepts `state` and `emit` as constructor arguments.
+
+The simplest approach is to subclass `SkillRunDeps`:
+
+```python
+from dataclasses import dataclass, field
+
+from haiku.skills import Skill, SkillMetadata, SkillRunDeps
+
+
+@dataclass
+class MyDeps(SkillRunDeps):                # inherits state + emit
+    connection: object = field(init=False)
+
+    def __post_init__(self):
+        self.connection = open_connection()
+
+
+skill = Skill(
+    metadata=SkillMetadata(name="my-skill", description="Uses a custom connection."),
+    instructions="...",
+    toolsets=[my_external_toolset],
+    deps_type=MyDeps,
+)
+```
+
+Inheritance is not required — any class satisfying `SkillRunDepsProtocol` works, as long as its constructor accepts `state` and `emit` keyword arguments.
+
+When `deps_type` is set, the skill sub-agent is created with `MyDeps(state=state, emit=emit)` instead of `SkillRunDeps(state=state, emit=emit)`. Any additional attributes are available to toolset tools via `ctx.deps`.
+
+See [Lifespan](lifespan.md) for a common pairing: a custom deps class whose fields are populated by a lifespan context manager.

--- a/docs/lifespan.md
+++ b/docs/lifespan.md
@@ -103,3 +103,6 @@ Every call to the skill constructs a fresh `deps` instance and enters a fresh CM
 ## Scope
 
 The lifespan fires in **sub-agent mode** (the default for `SkillToolset`), where `execute_skill` delegates each request to the skill's sub-agent. It does **not** fire in direct-tool mode (`SkillToolset(use_subagents=False)`), because that path exposes individual tools on the outer agent and has no well-defined invocation boundary. If you need per-call resources in direct mode, manage them inside the tool function.
+
+!!! note
+    `SkillToolset` emits a `UserWarning` at construction time if you register a skill with a `lifespan` while in direct-tool mode, so the silent no-op doesn't catch you off-guard.

--- a/docs/lifespan.md
+++ b/docs/lifespan.md
@@ -1,0 +1,105 @@
+# Lifespan
+
+A skill's **lifespan** is an async context manager that wraps one skill invocation — i.e. one run of the sub-agent. Use it to allocate resources the skill's tools will share across tool calls and dispose of them cleanly when the invocation ends, including on exceptions.
+
+Typical use cases:
+
+- Open a database or API client once and reuse it across tool calls (avoid per-call connect/disconnect).
+- Scope a per-invocation counter, cache, or sandbox to the run (prevents leaks across invocations).
+- Acquire a lock, register a subscription, or start a background worker that must be torn down when the skill is done.
+
+## Defining a lifespan
+
+The lifespan is a factory — a callable that receives the skill's `deps` and returns an async context manager. Setup happens before `yield`; teardown in `finally` after. The yielded value is ignored by the framework; store per-invocation state on `deps` directly.
+
+Pair a lifespan with `deps_type=` so tools get typed access:
+
+```python
+from collections.abc import Callable
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from ag_ui.core import BaseEvent
+from pydantic import BaseModel
+from pydantic_ai import RunContext
+from haiku.skills import Skill, SkillMetadata
+
+
+@dataclass
+class MyDeps:
+    state: BaseModel | None = None
+    emit: Callable[[BaseEvent], None] = field(default=lambda _: None)
+    db: MyClient | None = None
+    calls: int = 0
+
+
+@asynccontextmanager
+async def lifespan(deps: MyDeps):
+    deps.db = await MyClient.connect(url="...")
+    try:
+        yield
+    finally:
+        await deps.db.close()
+
+
+def search(ctx: RunContext[MyDeps], query: str) -> str:
+    """Search the database."""
+    assert ctx.deps.db is not None
+    ctx.deps.calls += 1
+    return ctx.deps.db.query(query)
+
+
+skill = Skill(
+    metadata=SkillMetadata(name="search", description="Searches the DB."),
+    instructions="Use the search tool to answer questions.",
+    tools=[search],
+    deps_type=MyDeps,
+    lifespan=lifespan,
+)
+```
+
+Every call to the skill's sub-agent enters the CM once, runs the agent (which may call `search` multiple times — they all see the same `db` and the same `calls` counter), and exits the CM once. The next invocation gets a fresh `MyDeps` instance and a new `db`.
+
+Any dataclass with `state` and `emit` satisfies `SkillRunDepsProtocol` — add whatever fields your lifespan and tools need.
+
+## Without a custom deps class
+
+A lifespan can do useful work without a custom deps class — for example, acquire a lock, emit events, or modify `deps.state`:
+
+```python
+@asynccontextmanager
+async def lifespan(deps):
+    await lock.acquire()
+    try:
+        yield
+    finally:
+        lock.release()
+
+skill = Skill(
+    metadata=SkillMetadata(name="guarded", description="Takes a lock."),
+    instructions="Do guarded work.",
+    tools=[...],
+    lifespan=lifespan,
+)
+```
+
+## Exception handling
+
+`async with` semantics are preserved: if any tool raises, the CM's `__aexit__` receives the exception and can clean up. The exception then propagates out of the skill run.
+
+```python
+@asynccontextmanager
+async def lifespan(deps: MyDeps):
+    conn = await pool.acquire()
+    try:
+        yield
+    finally:
+        await pool.release(conn)  # always runs, even on tool errors
+```
+
+## Per-invocation isolation
+
+Every call to the skill constructs a fresh `deps` instance and enters a fresh CM. Two concurrent or sequential invocations of the same skill do not share state unless you deliberately capture something in the factory's closure.
+
+## Scope
+
+The lifespan fires in **sub-agent mode** (the default for `SkillToolset`), where `execute_skill` delegates each request to the skill's sub-agent. It does **not** fire in direct-tool mode (`SkillToolset(use_subagents=False)`), because that path exposes individual tools on the outer agent and has no well-defined invocation boundary. If you need per-call resources in direct mode, manage them inside the tool function.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -219,34 +219,4 @@ meta = skill.state_metadata()
 
 Returns `None` for skills without state.
 
-## Custom deps (advanced)
-
-By default, skill sub-agents receive `SkillRunDeps` — a dataclass with `state` and `emit`. Skills that integrate external toolsets requiring additional context on the deps object can declare a `deps_type` — any class that satisfies `SkillRunDepsProtocol` (must have `state: BaseModel | None` and `emit: Callable`) and accepts `state` and `emit` as constructor arguments.
-
-The simplest approach is to subclass `SkillRunDeps`:
-
-```python
-from dataclasses import dataclass, field
-
-from haiku.skills import Skill, SkillMetadata, SkillRunDeps
-
-
-@dataclass
-class MyDeps(SkillRunDeps):                # inherits state + emit
-    connection: object = field(init=False)
-
-    def __post_init__(self):
-        self.connection = open_connection()
-
-
-skill = Skill(
-    metadata=SkillMetadata(name="my-skill", description="Uses a custom connection."),
-    instructions="...",
-    toolsets=[my_external_toolset],
-    deps_type=MyDeps,
-)
-```
-
-Inheritance is not required — any class satisfying `SkillRunDepsProtocol` works, as long as its constructor accepts `state` and `emit` keyword arguments.
-
-When `deps_type` is set, the skill sub-agent is created with `MyDeps(state=state, emit=emit)` instead of `SkillRunDeps(state=state, emit=emit)`. Any additional attributes are available to toolset tools via `ctx.deps`.
+Skills can also declare a `deps_type` to extend the default `SkillRunDeps` with additional fields for toolsets or lifespan-managed resources. See [Custom dependencies](custom-dependencies.md).

--- a/haiku/skills/agent.py
+++ b/haiku/skills/agent.py
@@ -6,6 +6,7 @@ import shlex
 import sys
 import time
 from collections.abc import AsyncIterable, Awaitable, Callable
+from contextlib import nullcontext
 from pathlib import Path
 from typing import Any
 
@@ -276,13 +277,15 @@ async def _run_skill(
     model_settings = (
         ModelSettings(thinking=skill.thinking) if skill.thinking is not None else None
     )
-    result = await agent.run(
-        request,
-        deps=deps,
-        usage_limits=UsageLimits(request_limit=20),
-        event_stream_handler=event_handler,
-        model_settings=model_settings,
-    )
+    cm: Any = skill._lifespan(deps) if skill._lifespan is not None else nullcontext()
+    async with cm:
+        result = await agent.run(
+            request,
+            deps=deps,
+            usage_limits=UsageLimits(request_limit=20),
+            event_stream_handler=event_handler,
+            model_settings=model_settings,
+        )
     text = result.output
     return text, collected_events, emitted_events
 

--- a/haiku/skills/agent.py
+++ b/haiku/skills/agent.py
@@ -5,6 +5,7 @@ import os
 import shlex
 import sys
 import time
+import warnings
 from collections.abc import AsyncIterable, Awaitable, Callable
 from contextlib import nullcontext
 from pathlib import Path
@@ -445,6 +446,17 @@ class SkillToolset(FunctionToolset[Any]):
         if self._use_subagents:
             self._register_subagent_tools()
         else:
+            for name in self._registry.names:
+                skill = self._registry.get(name)
+                if skill is not None and skill.lifespan is not None:
+                    warnings.warn(
+                        f"Skill '{skill.metadata.name}' has a lifespan, but "
+                        "SkillToolset is using direct-tool mode "
+                        "(use_subagents=False). Lifespans only fire in "
+                        "sub-agent mode — the hook will not run.",
+                        UserWarning,
+                        stacklevel=3,
+                    )
             self._register_direct_tools()
 
     def _register_subagent_tools(self) -> None:

--- a/haiku/skills/models.py
+++ b/haiku/skills/models.py
@@ -1,5 +1,6 @@
 import unicodedata
 from collections.abc import Callable, Sequence
+from contextlib import AbstractAsyncContextManager
 from dataclasses import dataclass
 from enum import StrEnum
 from pathlib import Path
@@ -12,6 +13,8 @@ from pydantic_ai.settings import ThinkingLevel
 from pydantic_ai.toolsets import AbstractToolset
 
 from haiku.skills.state import SkillRunDepsProtocol
+
+LifespanFactory = Callable[[Any], AbstractAsyncContextManager[None]]
 
 
 @dataclass(frozen=True)
@@ -91,6 +94,7 @@ class Skill(BaseModel):
     _thinking: ThinkingLevel | None = PrivateAttr(default=None)
     _factory: Callable[..., "Skill"] | None = PrivateAttr(default=None)
     _deps_type: type[SkillRunDepsProtocol] | None = PrivateAttr(default=None)
+    _lifespan: LifespanFactory | None = PrivateAttr(default=None)
 
     def __init__(
         self,
@@ -102,6 +106,7 @@ class Skill(BaseModel):
         extras: dict[str, Any] | None = None,
         thinking: ThinkingLevel | None = None,
         deps_type: type[SkillRunDepsProtocol] | None = None,
+        lifespan: LifespanFactory | None = None,
         **data: Any,
     ) -> None:
         super().__init__(**data)
@@ -112,6 +117,7 @@ class Skill(BaseModel):
         self._extras = dict(extras) if extras else {}
         self._thinking = thinking
         self._deps_type = deps_type
+        self._lifespan = lifespan
 
     @property
     def tools(self) -> list[Tool | Callable[..., Any]]:
@@ -169,6 +175,14 @@ class Skill(BaseModel):
     def deps_type(self, value: type[SkillRunDepsProtocol] | None) -> None:
         self._deps_type = value
 
+    @property
+    def lifespan(self) -> LifespanFactory | None:
+        return self._lifespan
+
+    @lifespan.setter
+    def lifespan(self, value: LifespanFactory | None) -> None:
+        self._lifespan = value
+
     def reconfigure(self, **kwargs: Any) -> None:
         """Re-create this skill with new factory arguments.
 
@@ -186,6 +200,7 @@ class Skill(BaseModel):
         self._extras = new_skill._extras
         self._thinking = new_skill._thinking
         self._deps_type = new_skill._deps_type
+        self._lifespan = new_skill._lifespan
         self.model = new_skill.model
         self.instructions = new_skill.instructions
         self.resources = new_skill.resources

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -57,10 +57,13 @@ nav:
       - Installation: installation.md
       - Tutorial: tutorial.md
       - Skills reference: skills.md
-      - Signing: signing.md
-      - CLI: cli.md
       - AG-UI protocol: ag-ui.md
+      - CLI: cli.md
       - Example skills: example-skills.md
+      - Advanced:
+          - Custom dependencies: custom-dependencies.md
+          - Lifespan: lifespan.md
+          - Signing: signing.md
       - Development: development.md
       - Changelog: changelog.md
 markdown_extensions:

--- a/skills/code-execution/haiku_skills_code_execution/SKILL.md
+++ b/skills/code-execution/haiku_skills_code_execution/SKILL.md
@@ -12,6 +12,9 @@ accomplish it and execute it using the run_code tool.
 - Use `await llm(prompt)` when the task requires reasoning about text
 - Execute the code and return the result
 - Report any errors clearly and retry with a fix if needed
+- Variables and definitions persist across `run_code` calls in the same
+  task — do expensive work (especially `await llm(...)`) once and reuse the
+  result in later calls rather than re-computing.
 
 ## Sandbox
 
@@ -39,4 +42,22 @@ for item in items:
     sentiment = await llm(f"Classify as positive/negative/neutral: {item}")
     results.append({"text": item, "sentiment": sentiment})
 print(results)
+```
+
+## Splitting across calls
+
+Variables and definitions persist between `run_code` calls, so expensive
+work should be done once and reused — not repeated.
+
+```python
+# Call 1 — classify once
+items = ["The food was great!", "Terrible service.", "Okay experience."]
+sentiments = [await llm(f"positive/negative/neutral: {item}") for item in items]
+print(sentiments)
+```
+
+```python
+# Call 2 — reuse items and sentiments, no re-classification
+positives = [item for item, s in zip(items, sentiments) if "positive" in s.lower()]
+print(positives)
 ```

--- a/skills/code-execution/haiku_skills_code_execution/__init__.py
+++ b/skills/code-execution/haiku_skills_code_execution/__init__.py
@@ -1,7 +1,10 @@
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
 from pathlib import Path
 
 from pydantic import BaseModel
 from pydantic_ai import RunContext
+from pydantic_monty import MontyRepl
 
 from haiku.skills.models import Skill
 from haiku.skills.parser import parse_skill_md
@@ -19,7 +22,20 @@ class CodeState(BaseModel):
     executions: list[Execution] = []
 
 
-async def run_code(ctx: RunContext[SkillRunDeps], code: str) -> str:
+@dataclass
+class CodeRunDeps(SkillRunDeps):
+    repl: MontyRepl | None = None
+
+
+@asynccontextmanager
+async def code_lifespan(deps: CodeRunDeps):
+    deps.repl = MontyRepl()
+    if isinstance(deps.state, CodeState):
+        deps.state.executions.clear()
+    yield
+
+
+async def run_code(ctx: RunContext[CodeRunDeps], code: str) -> str:
     """Execute Python code and return the output.
 
     Args:
@@ -31,11 +47,12 @@ async def run_code(ctx: RunContext[SkillRunDeps], code: str) -> str:
         _format_output,
     )
 
+    assert ctx.deps is not None and ctx.deps.repl is not None
     external_fns = _build_external_functions(ctx.model)
-    stdout, result, success = await _execute_code(code, external_fns)
+    stdout, result, success = await _execute_code(ctx.deps.repl, code, external_fns)
     output = _format_output(code, stdout, result)
 
-    if ctx.deps and ctx.deps.state and isinstance(ctx.deps.state, CodeState):
+    if ctx.deps.state and isinstance(ctx.deps.state, CodeState):
         ctx.deps.state.executions.append(
             Execution(
                 code=code,
@@ -58,4 +75,6 @@ def create_skill() -> Skill:
         tools=[run_code],
         state_type=CodeState,
         state_namespace="code-execution",
+        deps_type=CodeRunDeps,
+        lifespan=code_lifespan,
     )

--- a/skills/code-execution/haiku_skills_code_execution/sandbox.py
+++ b/skills/code-execution/haiku_skills_code_execution/sandbox.py
@@ -3,7 +3,7 @@
 from collections.abc import Callable
 from typing import Any
 
-from pydantic_monty import Monty, MontyError, run_monty_async
+from pydantic_monty import MontyError, MontyRepl, run_repl_async
 
 
 def _build_external_functions(model: Any) -> dict[str, Callable[..., Any]]:
@@ -23,11 +23,14 @@ def _build_external_functions(model: Any) -> dict[str, Callable[..., Any]]:
 
 
 async def _execute_code(
-    code: str, external_functions: dict[str, Callable[..., Any]] | None = None
+    repl: MontyRepl,
+    code: str,
+    external_functions: dict[str, Callable[..., Any]] | None = None,
 ) -> tuple[str, str | None, bool]:
-    """Execute code in the Monty sandbox.
+    """Execute code in a persistent Monty REPL.
 
     Args:
+        repl: REPL session whose heap and namespace persist across calls.
         code: The Python code to execute.
         external_functions: Functions available inside the sandbox.
 
@@ -40,8 +43,9 @@ async def _execute_code(
         output_lines.append(text)
 
     try:
-        result = await run_monty_async(
-            Monty(code),
+        result = await run_repl_async(
+            repl,
+            code,
             external_functions=external_functions or {},
             print_callback=print_callback,
         )

--- a/skills/sandbox/haiku_skills_sandbox/__init__.py
+++ b/skills/sandbox/haiku_skills_sandbox/__init__.py
@@ -1,6 +1,7 @@
 import atexit
 import os
 import time
+from contextlib import asynccontextmanager
 from pathlib import Path
 from uuid import uuid4
 
@@ -105,15 +106,17 @@ def create_skill(
         if env:
             workspace = Path(env)
 
-    from dataclasses import dataclass, field
+    from dataclasses import dataclass
 
     @dataclass
     class SandboxRunDeps(SkillRunDeps):
-        backend: DockerSandbox = field(init=False)
+        backend: DockerSandbox | None = None
 
-        def __post_init__(self) -> None:
-            state = self.state if isinstance(self.state, SandboxState) else None
-            self.backend = _get_sandbox(state, workspace, image, idle_timeout)
+    @asynccontextmanager
+    async def sandbox_lifespan(deps: SandboxRunDeps):
+        state = deps.state if isinstance(deps.state, SandboxState) else None
+        deps.backend = _get_sandbox(state, workspace, image, idle_timeout)
+        yield
 
     metadata, instructions = parse_skill_md(Path(__file__).parent / "SKILL.md")
     return Skill(
@@ -124,4 +127,5 @@ def create_skill(
         state_type=SandboxState,
         state_namespace="sandbox",
         deps_type=SandboxRunDeps,
+        lifespan=sandbox_lifespan,
     )

--- a/tests/skills/test_code_execution.py
+++ b/tests/skills/test_code_execution.py
@@ -1,9 +1,27 @@
 """Tests for the code execution skill package."""
 
-import pytest
-from pydantic_ai.models.test import TestModel
+from unittest.mock import MagicMock
 
-from tests.skills.conftest import make_ctx
+import pytest
+from pydantic_ai import RunContext
+from pydantic_ai.models import Model
+from pydantic_ai.models.test import TestModel
+from pydantic_monty import MontyRepl
+
+
+def _make_code_ctx(
+    state=None,
+    model: Model | None = None,
+    repl: MontyRepl | None = None,
+):
+    """Mock RunContext with CodeRunDeps populated (as the lifespan would)."""
+    from haiku_skills_code_execution import CodeRunDeps
+
+    ctx = MagicMock(spec=RunContext)
+    ctx.deps = CodeRunDeps(state=state, repl=repl if repl is not None else MontyRepl())
+    if model is not None:
+        ctx.model = model
+    return ctx
 
 
 class TestCreateSkill:
@@ -16,6 +34,8 @@ class TestCreateSkill:
         assert skill.state_type is not None
         assert skill.state_namespace == "code-execution"
         assert len(skill.tools) == 1
+        assert skill.deps_type is not None
+        assert skill.lifespan is not None
         assert skill.path is not None
 
 
@@ -65,44 +85,36 @@ class TestBuildExternalFunctions:
 class TestExecuteCode:
     @pytest.mark.anyio
     async def test_basic_expression(self):
-        from haiku_skills_code_execution.sandbox import (
-            _execute_code,
-        )
+        from haiku_skills_code_execution.sandbox import _execute_code
 
-        stdout, result, success = await _execute_code("1 + 1")
+        stdout, result, success = await _execute_code(MontyRepl(), "1 + 1")
         assert stdout == ""
         assert result == "2"
         assert success is True
 
     @pytest.mark.anyio
     async def test_print_output(self):
-        from haiku_skills_code_execution.sandbox import (
-            _execute_code,
-        )
+        from haiku_skills_code_execution.sandbox import _execute_code
 
-        stdout, result, success = await _execute_code("print('hello')")
+        stdout, result, success = await _execute_code(MontyRepl(), "print('hello')")
         assert "hello" in stdout
         assert result is None
         assert success is True
 
     @pytest.mark.anyio
     async def test_no_output(self):
-        from haiku_skills_code_execution.sandbox import (
-            _execute_code,
-        )
+        from haiku_skills_code_execution.sandbox import _execute_code
 
-        stdout, result, success = await _execute_code("x = 1")
+        stdout, result, success = await _execute_code(MontyRepl(), "x = 1")
         assert stdout == ""
         assert result is None
         assert success is True
 
     @pytest.mark.anyio
     async def test_monty_error(self):
-        from haiku_skills_code_execution.sandbox import (
-            _execute_code,
-        )
+        from haiku_skills_code_execution.sandbox import _execute_code
 
-        stdout, result, success = await _execute_code("1 / 0")
+        stdout, result, success = await _execute_code(MontyRepl(), "1 / 0")
         assert "Error" in (stdout or "")
         assert result is None
         assert success is False
@@ -117,17 +129,25 @@ class TestExecuteCode:
         model = TestModel(custom_output_text="Paris")
         external_fns = _build_external_functions(model)
         stdout, result, success = await _execute_code(
-            "x = await llm('capital of France')\nprint(x)", external_fns
+            MontyRepl(), "x = await llm('capital of France')\nprint(x)", external_fns
         )
         assert "Paris" in stdout
         assert success is True
 
+    @pytest.mark.anyio
+    async def test_repl_variables_persist_across_calls(self):
+        from haiku_skills_code_execution.sandbox import _execute_code
+
+        repl = MontyRepl()
+        await _execute_code(repl, "x = 41")
+        stdout, result, success = await _execute_code(repl, "x + 1")
+        assert success is True
+        assert result == "42"
+
 
 class TestFormatOutput:
     def test_stdout_and_result(self):
-        from haiku_skills_code_execution.sandbox import (
-            _format_output,
-        )
+        from haiku_skills_code_execution.sandbox import _format_output
 
         output = _format_output("x = 1\nprint(x)\nx", "1\n", "1")
         assert "```python" in output
@@ -136,9 +156,7 @@ class TestFormatOutput:
         assert "result: 1" in output
 
     def test_result_only(self):
-        from haiku_skills_code_execution.sandbox import (
-            _format_output,
-        )
+        from haiku_skills_code_execution.sandbox import _format_output
 
         output = _format_output("1 + 1", "", "2")
         assert "```python" in output
@@ -146,17 +164,13 @@ class TestFormatOutput:
         assert "stdout:" not in output
 
     def test_no_output(self):
-        from haiku_skills_code_execution.sandbox import (
-            _format_output,
-        )
+        from haiku_skills_code_execution.sandbox import _format_output
 
         output = _format_output("x = 1", "", None)
         assert "no output" in output.lower()
 
     def test_stdout_only(self):
-        from haiku_skills_code_execution.sandbox import (
-            _format_output,
-        )
+        from haiku_skills_code_execution.sandbox import _format_output
 
         output = _format_output("print('hi')", "hi\n", None)
         assert "stdout:" in output
@@ -168,8 +182,7 @@ class TestRunCodeAsync:
     async def test_basic_execution(self):
         from haiku_skills_code_execution import run_code
 
-        model = TestModel()
-        ctx = make_ctx(model=model)
+        ctx = _make_code_ctx(model=TestModel())
         result = await run_code(ctx, "print('hello')")
         assert "hello" in result
 
@@ -177,8 +190,7 @@ class TestRunCodeAsync:
     async def test_result_value(self):
         from haiku_skills_code_execution import run_code
 
-        model = TestModel()
-        ctx = make_ctx(model=model)
+        ctx = _make_code_ctx(model=TestModel())
         result = await run_code(ctx, "1 + 1")
         assert "result: 2" in result
 
@@ -186,8 +198,7 @@ class TestRunCodeAsync:
     async def test_no_output(self):
         from haiku_skills_code_execution import run_code
 
-        model = TestModel()
-        ctx = make_ctx(model=model)
+        ctx = _make_code_ctx(model=TestModel())
         result = await run_code(ctx, "x = 1")
         assert "no output" in result.lower()
 
@@ -196,8 +207,7 @@ class TestRunCodeAsync:
         from haiku_skills_code_execution import CodeState, run_code
 
         state = CodeState()
-        model = TestModel()
-        ctx = make_ctx(state=state, model=model)
+        ctx = _make_code_ctx(state=state, model=TestModel())
         result = await run_code(ctx, "print(1 + 1)")
         assert "2" in result
         assert len(state.executions) == 1
@@ -209,29 +219,17 @@ class TestRunCodeAsync:
         from haiku_skills_code_execution import CodeState, run_code
 
         state = CodeState()
-        model = TestModel()
-        ctx = make_ctx(state=state, model=model)
+        ctx = _make_code_ctx(state=state, model=TestModel())
         result = await run_code(ctx, "1 + 1")
         assert "result: 2" in result
         assert len(state.executions) == 1
         assert state.executions[0].result == "2"
 
     @pytest.mark.anyio
-    async def test_without_state(self):
-        from haiku_skills_code_execution import run_code
-
-        model = TestModel()
-        ctx = make_ctx(model=model)
-        ctx.deps = None
-        result = await run_code(ctx, "1 + 1")
-        assert "result: 2" in result
-
-    @pytest.mark.anyio
     async def test_with_llm(self):
         from haiku_skills_code_execution import run_code
 
-        model = TestModel(custom_output_text="Paris")
-        ctx = make_ctx(model=model)
+        ctx = _make_code_ctx(model=TestModel(custom_output_text="Paris"))
         result = await run_code(ctx, "x = await llm('capital of France')\nprint(x)")
         assert "Paris" in result
 
@@ -239,8 +237,7 @@ class TestRunCodeAsync:
     async def test_error_handling(self):
         from haiku_skills_code_execution import run_code
 
-        model = TestModel()
-        ctx = make_ctx(model=model)
+        ctx = _make_code_ctx(model=TestModel())
         result = await run_code(ctx, "1 / 0")
         assert "Error" in result
 
@@ -249,9 +246,60 @@ class TestRunCodeAsync:
         from haiku_skills_code_execution import CodeState, run_code
 
         state = CodeState()
-        model = TestModel()
-        ctx = make_ctx(state=state, model=model)
+        ctx = _make_code_ctx(state=state, model=TestModel())
         result = await run_code(ctx, "1 / 0")
         assert "Error" in result
         assert len(state.executions) == 1
         assert state.executions[0].success is False
+
+    @pytest.mark.anyio
+    async def test_variables_persist_across_tool_calls(self):
+        from haiku_skills_code_execution import run_code
+
+        ctx = _make_code_ctx(model=TestModel())
+        await run_code(ctx, "x = 41")
+        result = await run_code(ctx, "x + 1")
+        assert "result: 42" in result
+
+
+class TestCodeLifespan:
+    @pytest.mark.anyio
+    async def test_lifespan_populates_repl(self):
+        from haiku_skills_code_execution import create_skill
+
+        skill = create_skill()
+        assert skill.deps_type is not None
+        assert skill.lifespan is not None
+
+        deps = skill.deps_type(state=None, emit=lambda _: None)
+        assert deps.repl is None
+        async with skill.lifespan(deps):
+            assert isinstance(deps.repl, MontyRepl)
+
+    @pytest.mark.anyio
+    async def test_lifespan_clears_executions(self):
+        from haiku_skills_code_execution import CodeState, Execution, create_skill
+
+        skill = create_skill()
+        assert skill.deps_type is not None
+        assert skill.lifespan is not None
+
+        state = CodeState(
+            executions=[Execution(code="x = 1", stdout="", result=None, success=True)]
+        )
+        deps = skill.deps_type(state=state, emit=lambda _: None)
+
+        async with skill.lifespan(deps):
+            assert state.executions == []
+
+    @pytest.mark.anyio
+    async def test_lifespan_without_state_does_not_raise(self):
+        from haiku_skills_code_execution import create_skill
+
+        skill = create_skill()
+        assert skill.deps_type is not None
+        assert skill.lifespan is not None
+
+        deps = skill.deps_type(state=None, emit=lambda _: None)
+        async with skill.lifespan(deps):
+            pass

--- a/tests/skills/test_sandbox.py
+++ b/tests/skills/test_sandbox.py
@@ -1,9 +1,21 @@
 """Tests for the sandbox skill package."""
 
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
+from haiku.skills.models import Skill
 from haiku.skills.state import SkillRunDeps, SkillRunDepsProtocol
+
+
+async def _run_lifespan(skill: Skill, state: Any = None) -> Any:
+    """Construct deps and drive the skill's lifespan, returning populated deps."""
+    assert skill.deps_type is not None
+    assert skill.lifespan is not None
+    deps = skill.deps_type(state=state, emit=lambda _: None)
+    async with skill.lifespan(deps):
+        pass
+    return deps
 
 
 class TestCreateSkill:
@@ -17,6 +29,7 @@ class TestCreateSkill:
         assert skill.state_namespace == "sandbox"
         assert len(skill.toolsets) >= 1
         assert skill.deps_type is not None
+        assert skill.lifespan is not None
         assert skill.path is not None
 
     def test_create_skill_with_workspace(self):
@@ -32,38 +45,36 @@ class TestCreateSkill:
         assert skill.deps_type is not None
         assert issubclass(skill.deps_type, SkillRunDeps)
 
-    def test_workspace_from_env(self, monkeypatch):
+    async def test_workspace_from_env(self, monkeypatch):
         from haiku_skills_sandbox import SandboxState, _sandboxes, create_skill
 
         monkeypatch.setenv("HAIKU_SKILLS_SANDBOX_WORKSPACE", "/env/data")
         _sandboxes.clear()
         skill = create_skill()
-        assert skill.deps_type is not None
         state = SandboxState()
 
         with patch("haiku_skills_sandbox.DockerSandbox") as MockSandbox:
             mock_instance = MagicMock()
             MockSandbox.return_value = mock_instance
 
-            skill.deps_type(state=state, emit=lambda _: None)
+            await _run_lifespan(skill, state=state)
 
         call_kwargs = MockSandbox.call_args[1]
         assert call_kwargs["volumes"] == {"/env/data": "/workspace"}
 
-    def test_explicit_workspace_overrides_env(self, monkeypatch):
+    async def test_explicit_workspace_overrides_env(self, monkeypatch):
         from haiku_skills_sandbox import SandboxState, _sandboxes, create_skill
 
         monkeypatch.setenv("HAIKU_SKILLS_SANDBOX_WORKSPACE", "/env/data")
         _sandboxes.clear()
         skill = create_skill(workspace=Path("/explicit"))
-        assert skill.deps_type is not None
         state = SandboxState()
 
         with patch("haiku_skills_sandbox.DockerSandbox") as MockSandbox:
             mock_instance = MagicMock()
             MockSandbox.return_value = mock_instance
 
-            skill.deps_type(state=state, emit=lambda _: None)
+            await _run_lifespan(skill, state=state)
 
         call_kwargs = MockSandbox.call_args[1]
         assert call_kwargs["volumes"] == {"/explicit": "/workspace"}
@@ -269,7 +280,7 @@ class TestIdleCleanup:
         monkeypatch.setenv("HAIKU_SKILLS_SANDBOX_IDLE_TIMEOUT", "120")
         assert haiku_skills_sandbox._default_idle_timeout() == 120
 
-    def test_per_sandbox_timeout_via_create_skill(self):
+    async def test_per_sandbox_timeout_via_create_skill(self):
         import time
 
         from haiku_skills_sandbox import (
@@ -285,7 +296,6 @@ class TestIdleCleanup:
         _timeouts.clear()
 
         skill = create_skill(idle_timeout=10)
-        assert skill.deps_type is not None
         state = SandboxState()
 
         with patch("haiku_skills_sandbox.DockerSandbox") as MockSandbox:
@@ -293,7 +303,7 @@ class TestIdleCleanup:
             new_sandbox = MagicMock()
             MockSandbox.side_effect = [old_sandbox, new_sandbox]
 
-            skill.deps_type(state=state, emit=lambda _: None)
+            await _run_lifespan(skill, state=state)
             session_id = state.session_id
             assert session_id is not None
             assert _timeouts[session_id] == 10
@@ -301,11 +311,11 @@ class TestIdleCleanup:
             # Simulate idle beyond the per-sandbox timeout
             _last_active[session_id] = time.monotonic() - 20
 
-            skill.deps_type(state=state, emit=lambda _: None)
+            await _run_lifespan(skill, state=state)
 
         old_sandbox.stop.assert_called_once()
 
-    def test_per_sandbox_timeout_overrides_env(self, monkeypatch):
+    async def test_per_sandbox_timeout_overrides_env(self, monkeypatch):
         import time
 
         from haiku_skills_sandbox import (
@@ -322,7 +332,6 @@ class TestIdleCleanup:
         _timeouts.clear()
 
         skill = create_skill(idle_timeout=10)
-        assert skill.deps_type is not None
         state = SandboxState()
 
         with patch("haiku_skills_sandbox.DockerSandbox") as MockSandbox:
@@ -330,14 +339,14 @@ class TestIdleCleanup:
             new_sandbox = MagicMock()
             MockSandbox.side_effect = [old_sandbox, new_sandbox]
 
-            skill.deps_type(state=state, emit=lambda _: None)
+            await _run_lifespan(skill, state=state)
             session_id = state.session_id
             assert session_id is not None
 
             # Idle beyond per-sandbox timeout (10s) but within env timeout (9999s)
             _last_active[session_id] = time.monotonic() - 20
 
-            skill.deps_type(state=state, emit=lambda _: None)
+            await _run_lifespan(skill, state=state)
 
         # Per-sandbox timeout wins — sandbox is cleaned up
         old_sandbox.stop.assert_called_once()
@@ -355,37 +364,35 @@ class TestImage:
         monkeypatch.setenv("HAIKU_SKILLS_SANDBOX_IMAGE", "custom:v1")
         assert _resolve_image() == "custom:v1"
 
-    def test_image_from_create_skill(self):
+    async def test_image_from_create_skill(self):
         from haiku_skills_sandbox import SandboxState, _sandboxes, create_skill
 
         _sandboxes.clear()
         skill = create_skill(image="my-image:latest")
-        assert skill.deps_type is not None
         state = SandboxState()
 
         with patch("haiku_skills_sandbox.DockerSandbox") as MockSandbox:
             mock_instance = MagicMock()
             MockSandbox.return_value = mock_instance
 
-            skill.deps_type(state=state, emit=lambda _: None)
+            await _run_lifespan(skill, state=state)
 
         call_kwargs = MockSandbox.call_args[1]
         assert call_kwargs["image"] == "my-image:latest"
 
-    def test_create_skill_image_overrides_env(self, monkeypatch):
+    async def test_create_skill_image_overrides_env(self, monkeypatch):
         from haiku_skills_sandbox import SandboxState, _sandboxes, create_skill
 
         monkeypatch.setenv("HAIKU_SKILLS_SANDBOX_IMAGE", "env-image:v1")
         _sandboxes.clear()
         skill = create_skill(image="explicit:v2")
-        assert skill.deps_type is not None
         state = SandboxState()
 
         with patch("haiku_skills_sandbox.DockerSandbox") as MockSandbox:
             mock_instance = MagicMock()
             MockSandbox.return_value = mock_instance
 
-            skill.deps_type(state=state, emit=lambda _: None)
+            await _run_lifespan(skill, state=state)
 
         call_kwargs = MockSandbox.call_args[1]
         assert call_kwargs["image"] == "explicit:v2"
@@ -424,26 +431,24 @@ class TestSandboxRunDeps:
         skill = create_skill()
         assert skill.deps_type is not None
 
-        with patch("haiku_skills_sandbox.DockerSandbox"):
-            deps = skill.deps_type(state=None, emit=lambda _: None)
-
+        deps = skill.deps_type(state=None, emit=lambda _: None)
         assert isinstance(deps, SkillRunDepsProtocol)
+        assert deps.backend is None
 
-    def test_has_backend(self):
+    async def test_lifespan_populates_backend(self):
         from haiku_skills_sandbox import create_skill
 
         skill = create_skill()
-        assert skill.deps_type is not None
 
         with patch("haiku_skills_sandbox.DockerSandbox") as MockSandbox:
             mock_instance = MagicMock()
             MockSandbox.return_value = mock_instance
 
-            deps = skill.deps_type(state=None, emit=lambda _: None)
+            deps = await _run_lifespan(skill)
 
         assert deps.backend is mock_instance
 
-    def test_backend_uses_state_for_session_binding(self):
+    async def test_backend_uses_state_for_session_binding(self):
         from haiku_skills_sandbox import (
             SandboxState,
             _sandboxes,
@@ -452,34 +457,32 @@ class TestSandboxRunDeps:
 
         _sandboxes.clear()
         skill = create_skill()
-        assert skill.deps_type is not None
         state = SandboxState()
 
         with patch("haiku_skills_sandbox.DockerSandbox") as MockSandbox:
             mock_instance = MagicMock()
             MockSandbox.return_value = mock_instance
 
-            deps1 = skill.deps_type(state=state, emit=lambda _: None)
+            deps1 = await _run_lifespan(skill, state=state)
             session_id = state.session_id
 
         assert session_id is not None
-        deps2 = skill.deps_type(state=state, emit=lambda _: None)
+        deps2 = await _run_lifespan(skill, state=state)
 
         assert deps1.backend is deps2.backend
 
-    def test_workspace_captured_in_closure(self):
+    async def test_workspace_captured_in_closure(self):
         from haiku_skills_sandbox import SandboxState, _sandboxes, create_skill
 
         _sandboxes.clear()
         skill = create_skill(workspace=Path("/my/data"))
-        assert skill.deps_type is not None
         state = SandboxState()
 
         with patch("haiku_skills_sandbox.DockerSandbox") as MockSandbox:
             mock_instance = MagicMock()
             MockSandbox.return_value = mock_instance
 
-            skill.deps_type(state=state, emit=lambda _: None)
+            await _run_lifespan(skill, state=state)
 
         call_kwargs = MockSandbox.call_args[1]
         assert call_kwargs["volumes"] == {"/my/data": "/workspace"}

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -1,0 +1,226 @@
+from collections.abc import Callable
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from ag_ui.core import BaseEvent
+from pydantic import BaseModel
+from pydantic_ai import RunContext
+from pydantic_ai.models.test import TestModel
+
+from haiku.skills.agent import _run_skill
+from haiku.skills.models import Skill, SkillMetadata, SkillSource
+from haiku.skills.state import SkillRunDeps, SkillRunDepsProtocol
+
+
+@dataclass
+class DepsWithDB:
+    state: BaseModel | None = None
+    emit: Callable[[BaseEvent], None] = field(default=lambda _: None)
+    db: Any = None
+    calls: int = 0
+
+
+class TestLifespan:
+    async def test_hook_fires_once_across_tool_calls(
+        self, allow_model_requests: None
+    ) -> None:
+        events: list[str] = []
+        observed: list[Any] = []
+
+        @asynccontextmanager
+        async def lifespan(deps: DepsWithDB):
+            events.append("enter")
+            deps.db = "connected"
+            try:
+                yield
+            finally:
+                events.append("exit")
+                deps.db = "closed"
+
+        def ping_a(ctx: RunContext[DepsWithDB]) -> str:
+            """Ping a."""
+            ctx.deps.calls += 1
+            observed.append(ctx.deps.db)
+            return "a"
+
+        def ping_b(ctx: RunContext[DepsWithDB]) -> str:
+            """Ping b."""
+            ctx.deps.calls += 1
+            observed.append(ctx.deps.db)
+            return "b"
+
+        def ping_c(ctx: RunContext[DepsWithDB]) -> str:
+            """Ping c."""
+            ctx.deps.calls += 1
+            observed.append(ctx.deps.db)
+            return "c"
+
+        skill = Skill(
+            metadata=SkillMetadata(name="pinger", description="Pings."),
+            source=SkillSource.ENTRYPOINT,
+            instructions="Ping.",
+            tools=[ping_a, ping_b, ping_c],
+            deps_type=DepsWithDB,
+            lifespan=lifespan,
+        )
+
+        result, *_ = await _run_skill(TestModel(), skill, "Ping all three.")
+
+        assert result
+        assert events == ["enter", "exit"]
+        assert observed == ["connected", "connected", "connected"]
+
+    async def test_exception_propagates_through_cm(
+        self, allow_model_requests: None
+    ) -> None:
+        exit_info: dict[str, Any] = {}
+
+        class Lifespan:
+            async def __aenter__(self) -> None:
+                return None
+
+            async def __aexit__(
+                self,
+                exc_type: type[BaseException] | None,
+                exc: BaseException | None,
+                tb: Any,
+            ) -> None:
+                exit_info["exc_type"] = exc_type
+                exit_info["exc"] = exc
+
+        def factory(deps: SkillRunDepsProtocol) -> Lifespan:
+            return Lifespan()
+
+        def boom(ctx: RunContext[SkillRunDeps]) -> str:
+            """Raise on call."""
+            raise RuntimeError("boom")
+
+        skill = Skill(
+            metadata=SkillMetadata(name="boomer", description="Raises."),
+            source=SkillSource.ENTRYPOINT,
+            instructions="Call boom.",
+            tools=[boom],
+            lifespan=factory,
+        )
+
+        with pytest.raises(Exception):
+            await _run_skill(TestModel(), skill, "Boom.")
+
+        assert exit_info["exc_type"] is not None
+        assert exit_info["exc"] is not None
+
+    async def test_no_lifespan_is_noop(self, allow_model_requests: None) -> None:
+        def noop() -> str:
+            """No-op."""
+            return "ok"
+
+        skill = Skill(
+            metadata=SkillMetadata(name="noop", description="Noop."),
+            source=SkillSource.ENTRYPOINT,
+            instructions="Call noop.",
+            tools=[noop],
+        )
+
+        assert skill.lifespan is None
+        result, *_ = await _run_skill(TestModel(), skill, "Do it.")
+        assert result
+
+    async def test_per_invocation_isolation(self, allow_model_requests: None) -> None:
+        enters: list[int] = []
+        observed: list[int] = []
+
+        @asynccontextmanager
+        async def lifespan(deps: DepsWithDB):
+            deps.calls = 0
+            enters.append(id(deps))
+            yield
+
+        def ping(ctx: RunContext[DepsWithDB]) -> str:
+            """Ping."""
+            ctx.deps.calls += 1
+            observed.append(ctx.deps.calls)
+            return "pong"
+
+        skill = Skill(
+            metadata=SkillMetadata(name="pinger", description="Pings."),
+            source=SkillSource.ENTRYPOINT,
+            instructions="Ping once.",
+            tools=[ping],
+            deps_type=DepsWithDB,
+            lifespan=lifespan,
+        )
+
+        await _run_skill(TestModel(), skill, "Ping.")
+        await _run_skill(TestModel(), skill, "Ping again.")
+
+        assert len(enters) == 2
+        assert enters[0] != enters[1]
+        assert observed == [1, 1]
+
+    async def test_lifespan_without_custom_deps(
+        self, allow_model_requests: None
+    ) -> None:
+        """Lifespan can do useful work without requiring a custom deps class."""
+        events: list[str] = []
+
+        @asynccontextmanager
+        async def lifespan(deps: SkillRunDeps):
+            events.append("enter")
+            try:
+                yield
+            finally:
+                events.append("exit")
+
+        def noop() -> str:
+            """No-op."""
+            return "ok"
+
+        skill = Skill(
+            metadata=SkillMetadata(name="noop", description="Noop."),
+            source=SkillSource.ENTRYPOINT,
+            instructions="Call noop.",
+            tools=[noop],
+            lifespan=lifespan,
+        )
+
+        await _run_skill(TestModel(), skill, "Do it.")
+        assert events == ["enter", "exit"]
+
+    async def test_reconfigure_preserves_lifespan(self) -> None:
+        @asynccontextmanager
+        async def lifespan(deps: SkillRunDepsProtocol):
+            yield
+
+        def make_skill(**_: Any) -> Skill:
+            return Skill(
+                metadata=SkillMetadata(name="s", description="s."),
+                source=SkillSource.ENTRYPOINT,
+                instructions="x",
+                lifespan=lifespan,
+            )
+
+        skill = make_skill()
+        skill._factory = make_skill
+        assert skill.lifespan is lifespan
+
+        skill.reconfigure()
+        assert skill.lifespan is lifespan
+
+
+class TestLifespanProperty:
+    def test_lifespan_setter(self) -> None:
+        @asynccontextmanager
+        async def lifespan(deps: SkillRunDepsProtocol):
+            yield
+
+        skill = Skill(
+            metadata=SkillMetadata(name="s", description="s."),
+            source=SkillSource.ENTRYPOINT,
+        )
+        assert skill.lifespan is None
+        skill.lifespan = lifespan
+        assert skill.lifespan is lifespan
+        skill.lifespan = None
+        assert skill.lifespan is None

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -209,6 +209,57 @@ class TestLifespan:
         assert skill.lifespan is lifespan
 
 
+class TestDirectModeWarning:
+    def test_warns_when_direct_mode_skill_has_lifespan(self) -> None:
+        from haiku.skills.agent import SkillToolset
+
+        @asynccontextmanager
+        async def lifespan(deps: SkillRunDepsProtocol):
+            yield
+
+        skill = Skill(
+            metadata=SkillMetadata(name="hooked", description="h."),
+            source=SkillSource.ENTRYPOINT,
+            lifespan=lifespan,
+        )
+
+        with pytest.warns(UserWarning, match="lifespan"):
+            SkillToolset(skills=[skill], use_subagents=False)
+
+    def test_no_warning_in_subagent_mode(self) -> None:
+        import warnings
+
+        from haiku.skills.agent import SkillToolset
+
+        @asynccontextmanager
+        async def lifespan(deps: SkillRunDepsProtocol):
+            yield
+
+        skill = Skill(
+            metadata=SkillMetadata(name="hooked", description="h."),
+            source=SkillSource.ENTRYPOINT,
+            lifespan=lifespan,
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            SkillToolset(skills=[skill])
+
+    def test_no_warning_in_direct_mode_without_lifespan(self) -> None:
+        import warnings
+
+        from haiku.skills.agent import SkillToolset
+
+        skill = Skill(
+            metadata=SkillMetadata(name="plain", description="p."),
+            source=SkillSource.ENTRYPOINT,
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            SkillToolset(skills=[skill], use_subagents=False)
+
+
 class TestLifespanProperty:
     def test_lifespan_setter(self) -> None:
         @asynccontextmanager


### PR DESCRIPTION
Adds an optional `lifespan` async context manager factory to `Skill` that wraps one sub-agent run. Use it to set up and tear down per-invocation resources, e.g. a database client opened once and reused across tool calls, a counter scoped to the run, or a lock held for the invocation's duration.
