### PR TITLE
Expose run_skill publicly and add Skill.request_limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- **`request_limit` on `Skill`**: Optional integer field that overrides the default 20-request usage limit when running a skill via `run_skill()`. Long-running skills (e.g. analysis skills that interleave search and code execution) can raise their ceiling without monkey-patching.
 - **`run_skill` is now public**: Re-exported from `haiku.skills`. Replaces the previously underscore-prefixed `_run_skill`.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Added
+
+- **`run_skill` is now public**: Re-exported from `haiku.skills`. Replaces the previously underscore-prefixed `_run_skill`.
+
+### Changed
+
+- **`_run_skill` renamed to `run_skill`**: Breaking. Update imports from `from haiku.skills.agent import _run_skill` to `from haiku.skills.agent import run_skill` (or `from haiku.skills import run_skill`).
+
 ## [0.15.1] - 2026-04-23
 
 ### Added

--- a/haiku/skills/__init__.py
+++ b/haiku/skills/__init__.py
@@ -3,6 +3,7 @@ from haiku.skills.agent import (
     SkillToolset,
     resolve_model,
     run_agui_stream,
+    run_skill,
 )
 from haiku.skills.capability import SkillsCapability
 from haiku.skills.mcp import skill_from_mcp

--- a/haiku/skills/agent.py
+++ b/haiku/skills/agent.py
@@ -207,7 +207,7 @@ def _create_run_script(
     return run_script
 
 
-async def _run_skill(
+async def run_skill(
     model: str | Model,
     skill: Skill,
     request: str,
@@ -493,7 +493,7 @@ class SkillToolset(FunctionToolset[Any]):
             event_sink = self._event_sink
 
             try:
-                result, collected_events, emitted_events = await _run_skill(
+                result, collected_events, emitted_events = await run_skill(
                     skill_model, skill, request, state=state, event_sink=event_sink
                 )
             except Exception as e:

--- a/haiku/skills/agent.py
+++ b/haiku/skills/agent.py
@@ -283,7 +283,7 @@ async def run_skill(
         result = await agent.run(
             request,
             deps=deps,
-            usage_limits=UsageLimits(request_limit=20),
+            usage_limits=UsageLimits(request_limit=skill.request_limit or 20),
             event_stream_handler=event_handler,
             model_settings=model_settings,
         )

--- a/haiku/skills/models.py
+++ b/haiku/skills/models.py
@@ -86,6 +86,7 @@ class Skill(BaseModel):
     instructions: str | None = None
     resources: list[str] = Field(default_factory=list)
     model: str | Model | None = None
+    request_limit: int | None = None
     _tools: list[Tool | Callable[..., Any]] = PrivateAttr(default_factory=list)
     _toolsets: list[AbstractToolset[Any]] = PrivateAttr(default_factory=list)
     _state_type: type[BaseModel] | None = PrivateAttr(default=None)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -699,6 +699,49 @@ class TestRunSkillWithState:
         assert len(captured_settings) == 1
         assert captured_settings[0] is None
 
+    async def test_run_skill_default_request_limit_is_20(
+        self, allow_model_requests: None
+    ):
+        """Without skill.request_limit set, run_skill uses the legacy default of 20."""
+        captured_limits: list[Any] = []
+        original_run = Agent.run
+
+        async def patched_run(self: Any, *args: Any, **kwargs: Any) -> Any:
+            captured_limits.append(kwargs.get("usage_limits"))
+            return await original_run(self, *args, **kwargs)
+
+        skill = Skill(
+            metadata=SkillMetadata(name="a", description="Test."),
+            source=SkillSource.ENTRYPOINT,
+            instructions="Do it.",
+        )
+        with patch.object(Agent, "run", patched_run):
+            await run_skill(TestModel(call_tools=[]), skill, "Do it.")
+        assert len(captured_limits) == 1
+        assert captured_limits[0].request_limit == 20
+
+    async def test_run_skill_honors_skill_request_limit(
+        self, allow_model_requests: None
+    ):
+        """When skill.request_limit is set, run_skill passes it through."""
+        captured_limits: list[Any] = []
+        original_run = Agent.run
+
+        async def patched_run(self: Any, *args: Any, **kwargs: Any) -> Any:
+            captured_limits.append(kwargs.get("usage_limits"))
+            return await original_run(self, *args, **kwargs)
+
+        skill = Skill(
+            metadata=SkillMetadata(name="a", description="Test."),
+            source=SkillSource.ENTRYPOINT,
+            instructions="Do it.",
+            request_limit=50,
+        )
+        with patch.object(Agent, "run", patched_run):
+            await run_skill(TestModel(call_tools=[]), skill, "Do it.")
+        assert len(captured_limits) == 1
+        assert captured_limits[0].request_limit == 50
+
 
 class TestRunSkillDepsType:
     async def test_custom_deps_type_used(self, allow_model_requests: None):

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -30,9 +30,9 @@ from haiku.skills.agent import (
     _create_read_resource,
     _create_run_script,
     _events_to_activity,
-    _run_skill,
     resolve_model,
     run_agui_stream,
+    run_skill,
 )
 from haiku.skills.models import (
     Skill,
@@ -129,7 +129,7 @@ class TestRunSkill:
         toolset = SkillToolset(skill_paths=[FIXTURES])
         skill = toolset.registry.get("simple-skill")
         assert skill is not None
-        result, events, _ = await _run_skill(
+        result, events, _ = await run_skill(
             TestModel(call_tools=[]), skill, "Do something."
         )
         assert result
@@ -147,7 +147,7 @@ class TestRunSkill:
             instructions="Use the greet tool.",
             tools=[greet],
         )
-        result, events, _ = await _run_skill(TestModel(), skill, "Greet Alice.")
+        result, events, _ = await run_skill(TestModel(), skill, "Greet Alice.")
         assert result
         assert len(events) >= 2
         call_events = [
@@ -179,7 +179,7 @@ class TestRunSkill:
             instructions="Use the greet toolset.",
             toolsets=[toolset],
         )
-        result, events, _ = await _run_skill(TestModel(), skill, "Greet Alice.")
+        result, events, _ = await run_skill(TestModel(), skill, "Greet Alice.")
         assert result
         assert len(events) >= 2
 
@@ -201,7 +201,7 @@ class TestRunSkill:
             instructions="Use the greet tool.",
             tools=[greet],
         )
-        result, collected, _ = await _run_skill(
+        result, collected, _ = await run_skill(
             TestModel(), skill, "Greet Alice.", event_sink=sink
         )
         assert result
@@ -297,7 +297,7 @@ class TestRunSkillWithResources:
             instructions="Use references.",
             resources=["references/REFERENCE.md", "assets/template.txt"],
         )
-        result, *_ = await _run_skill(TestModel(call_tools=[]), skill, "Do something.")
+        result, *_ = await run_skill(TestModel(call_tools=[]), skill, "Do something.")
         assert result
 
     async def test_no_resources_no_section(self, allow_model_requests: None):
@@ -306,7 +306,7 @@ class TestRunSkillWithResources:
             source=SkillSource.ENTRYPOINT,
             instructions="Do things.",
         )
-        result, *_ = await _run_skill(TestModel(call_tools=[]), skill, "Do something.")
+        result, *_ = await run_skill(TestModel(call_tools=[]), skill, "Do something.")
         assert result
 
 
@@ -353,7 +353,7 @@ class TestAgent:
     async def test_run_skill_exception_returns_error(
         self, monkeypatch: pytest.MonkeyPatch, allow_model_requests: None
     ):
-        """Exception during _run_skill returns an error string."""
+        """Exception during run_skill returns an error string."""
 
         def exploding_tool() -> str:
             """Always raises."""
@@ -618,7 +618,7 @@ class TestSkillToolsetState:
 
 class TestRunSkillWithState:
     async def test_run_skill_passes_state_as_deps(self, allow_model_requests: None):
-        """Verify _run_skill passes state to the sub-agent as deps."""
+        """Verify run_skill passes state to the sub-agent as deps."""
         captured_deps: list[SkillRunDeps | None] = []
 
         def capture_tool(ctx: RunContext[SkillRunDeps | None]) -> str:
@@ -633,7 +633,7 @@ class TestRunSkillWithState:
             tools=[capture_tool],
         )
         state = CounterState(count=5)
-        await _run_skill(TestModel(), skill, "Do it.", state=state)
+        await run_skill(TestModel(), skill, "Do it.", state=state)
         assert len(captured_deps) == 1
         assert captured_deps[0] is not None
         assert captured_deps[0].state is state
@@ -653,7 +653,7 @@ class TestRunSkillWithState:
             instructions="Use capture_tool.",
             tools=[capture_tool],
         )
-        await _run_skill(TestModel(), skill, "Do it.")
+        await run_skill(TestModel(), skill, "Do it.")
         assert len(captured_deps) == 1
         assert captured_deps[0] is not None
         assert captured_deps[0].state is None
@@ -676,7 +676,7 @@ class TestRunSkillWithState:
             thinking="high",
         )
         with patch.object(Agent, "run", patched_run):
-            await _run_skill(TestModel(call_tools=[]), skill, "Do it.")
+            await run_skill(TestModel(call_tools=[]), skill, "Do it.")
         assert len(captured_settings) == 1
         assert captured_settings[0] == ModelSettings(thinking="high")
 
@@ -695,7 +695,7 @@ class TestRunSkillWithState:
             instructions="Do it.",
         )
         with patch.object(Agent, "run", patched_run):
-            await _run_skill(TestModel(call_tools=[]), skill, "Do it.")
+            await run_skill(TestModel(call_tools=[]), skill, "Do it.")
         assert len(captured_settings) == 1
         assert captured_settings[0] is None
 
@@ -729,7 +729,7 @@ class TestRunSkillDepsType:
             deps_type=CustomDeps,
         )
         state = CounterState(count=3)
-        await _run_skill(TestModel(), skill, "Do it.", state=state)
+        await run_skill(TestModel(), skill, "Do it.", state=state)
         assert len(captured_deps) == 1
         assert isinstance(captured_deps[0], CustomDeps)
         assert captured_deps[0].state is state
@@ -752,7 +752,7 @@ class TestRunSkillDepsType:
             instructions="Use capture_tool.",
             tools=[capture_tool],
         )
-        await _run_skill(TestModel(), skill, "Do it.")
+        await run_skill(TestModel(), skill, "Do it.")
         assert len(captured_deps) == 1
         assert isinstance(captured_deps[0], SkillRunDeps)
 
@@ -1527,7 +1527,7 @@ class TestRunSkillWithScripts:
             path=tmp_path,
             instructions="Use scripts.",
         )
-        result, *_ = await _run_skill(TestModel(call_tools=[]), skill, "Do something.")
+        result, *_ = await run_skill(TestModel(call_tools=[]), skill, "Do something.")
         assert result
 
     async def test_no_run_script_without_scripts_dir(self, allow_model_requests: None):
@@ -1536,7 +1536,7 @@ class TestRunSkillWithScripts:
             source=SkillSource.ENTRYPOINT,
             instructions="Do things.",
         )
-        result, *_ = await _run_skill(TestModel(call_tools=[]), skill, "Do something.")
+        result, *_ = await run_skill(TestModel(call_tools=[]), skill, "Do something.")
         assert result
 
 

--- a/tests/test_lifespan.py
+++ b/tests/test_lifespan.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 from pydantic_ai import RunContext
 from pydantic_ai.models.test import TestModel
 
-from haiku.skills.agent import _run_skill
+from haiku.skills.agent import run_skill
 from haiku.skills.models import Skill, SkillMetadata, SkillSource
 from haiku.skills.state import SkillRunDeps, SkillRunDepsProtocol
 
@@ -66,7 +66,7 @@ class TestLifespan:
             lifespan=lifespan,
         )
 
-        result, *_ = await _run_skill(TestModel(), skill, "Ping all three.")
+        result, *_ = await run_skill(TestModel(), skill, "Ping all three.")
 
         assert result
         assert events == ["enter", "exit"]
@@ -106,7 +106,7 @@ class TestLifespan:
         )
 
         with pytest.raises(Exception):
-            await _run_skill(TestModel(), skill, "Boom.")
+            await run_skill(TestModel(), skill, "Boom.")
 
         assert exit_info["exc_type"] is not None
         assert exit_info["exc"] is not None
@@ -124,7 +124,7 @@ class TestLifespan:
         )
 
         assert skill.lifespan is None
-        result, *_ = await _run_skill(TestModel(), skill, "Do it.")
+        result, *_ = await run_skill(TestModel(), skill, "Do it.")
         assert result
 
     async def test_per_invocation_isolation(self, allow_model_requests: None) -> None:
@@ -152,8 +152,8 @@ class TestLifespan:
             lifespan=lifespan,
         )
 
-        await _run_skill(TestModel(), skill, "Ping.")
-        await _run_skill(TestModel(), skill, "Ping again.")
+        await run_skill(TestModel(), skill, "Ping.")
+        await run_skill(TestModel(), skill, "Ping again.")
 
         assert len(enters) == 2
         assert enters[0] != enters[1]
@@ -185,7 +185,7 @@ class TestLifespan:
             lifespan=lifespan,
         )
 
-        await _run_skill(TestModel(), skill, "Do it.")
+        await run_skill(TestModel(), skill, "Do it.")
         assert events == ["enter", "exit"]
 
     async def test_reconfigure_preserves_lifespan(self) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -207,6 +207,16 @@ class TestSkill:
         skill = Skill(metadata=meta, source=SkillSource.FILESYSTEM)
         assert skill.resources == []
 
+    def test_request_limit_default_none(self):
+        meta = SkillMetadata(name="test", description="Test skill.")
+        skill = Skill(metadata=meta, source=SkillSource.FILESYSTEM)
+        assert skill.request_limit is None
+
+    def test_request_limit_settable(self):
+        meta = SkillMetadata(name="test", description="Test skill.")
+        skill = Skill(metadata=meta, source=SkillSource.FILESYSTEM, request_limit=100)
+        assert skill.request_limit == 100
+
     def test_resources_settable(self):
         meta = SkillMetadata(name="test", description="Test skill.")
         skill = Skill(metadata=meta, source=SkillSource.FILESYSTEM)


### PR DESCRIPTION

- **`request_limit` on `Skill`**: Optional integer field that overrides the default 20-request usage limit when running a skill via `run_skill()`. Long-running skills (e.g. analysis skills that interleave search and code execution) can raise their ceiling without monkey-patching.
- **`run_skill` is now public**: Re-exported from `haiku.skills`. Replaces the previously underscore-prefixed `_run_skill`.