### PR TITLE
Run skill agent with a retry budget of 3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Skill runs use a retry budget of 3 for both tool calls and output validation (`retries=3`, was the pydantic-ai default of 1), so a tool raising `ModelRetry` (or an output failing validation) gets more attempts before the run fails with `UnexpectedModelBehavior`.
+
 ## [0.17.1] - 2026-05-21
 
 ### Fixed

--- a/haiku/skills/agent.py
+++ b/haiku/skills/agent.py
@@ -279,6 +279,7 @@ async def run_skill(
         tools=tools,
         toolsets=skill.toolsets or None,
         capabilities=[ProcessEventStream(event_handler)],
+        retries=3,
     )
     model_settings = (
         ModelSettings(thinking=skill.thinking) if skill.thinking is not None else None

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -11,7 +11,7 @@ from ag_ui.core import (
     EventType,
 )
 from pydantic import BaseModel
-from pydantic_ai import Agent, RunContext, ToolReturn
+from pydantic_ai import Agent, ModelRetry, RunContext, ToolReturn
 from pydantic_ai.messages import (
     FunctionToolCallEvent,
     FunctionToolResultEvent,
@@ -164,6 +164,29 @@ class TestRunSkill:
         ]
         assert len(call_events) >= 1
         assert len(result_events) >= 1
+
+    async def test_run_skill_tools_allow_three_retries(
+        self, allow_model_requests: None
+    ):
+        attempts = {"n": 0}
+
+        def flaky() -> str:
+            """A tool that succeeds only on the fourth attempt."""
+            attempts["n"] += 1
+            if attempts["n"] < 4:
+                raise ModelRetry("not yet")
+            return "ok"
+
+        meta = SkillMetadata(name="flaky-skill", description="Retries.")
+        skill = Skill(
+            metadata=meta,
+            source=SkillSource.FILESYSTEM,
+            instructions="Use the flaky tool.",
+            tools=[flaky],
+        )
+        result, _, _ = await run_skill(TestModel(), skill, "Run it.")
+        assert result
+        assert attempts["n"] == 4
 
     async def test_run_skill_with_toolsets(self, allow_model_requests: None):
         def greet(name: str) -> str:


### PR DESCRIPTION
- Skill runs use a retry budget of 3 for both tool calls and output validation (`retries=3`, was the pydantic-ai default of 1), so a tool raising `ModelRetry` (or an output failing validation) gets more attempts before the run fails with `UnexpectedModelBehavior`.