### PR TITLE
Force a final answer when a skill run exhausts its request limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `Skill.force_final_answer` (default `True`): when a skill run exhausts its `request_limit`, `run_skill` makes one final tool-less completion seeded with the gathered message history instead of raising `UsageLimitExceeded`. Set `False` to restore the raising behavior.
+
 ## [0.17.2] - 2026-06-05
 
 ### Changed

--- a/haiku/skills/agent.py
+++ b/haiku/skills/agent.py
@@ -1,6 +1,7 @@
 import asyncio
 import inspect
 import json
+import logging
 import os
 import shlex
 import sys
@@ -8,6 +9,7 @@ import time
 import warnings
 from collections.abc import AsyncIterable, Awaitable, Callable
 from contextlib import nullcontext
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -17,22 +19,27 @@ from ag_ui.core import (
     EventType,
 )
 from pydantic import BaseModel
-from pydantic_ai import Agent, RunContext, Tool, ToolReturn, UsageLimits
+from pydantic_ai import Agent, RunContext, Tool, ToolReturn
+from pydantic_ai.capabilities import AbstractCapability
 from pydantic_ai.capabilities.process_event_stream import ProcessEventStream
+from pydantic_ai.exceptions import UsageLimitExceeded
 from pydantic_ai.messages import (
     AgentStreamEvent,
     FunctionToolCallEvent,
     FunctionToolResultEvent,
+    ModelMessage,
     RetryPromptPart,
 )
-from pydantic_ai.models import Model
+from pydantic_ai.models import Model, ModelRequestContext
 from pydantic_ai.settings import ModelSettings
 from pydantic_ai.toolsets import FunctionToolset
 
 from haiku.skills.models import Skill
-from haiku.skills.prompts import SKILL_PROMPT
+from haiku.skills.prompts import FORCE_FINAL_ANSWER_PROMPT, SKILL_PROMPT
 from haiku.skills.registry import SkillRegistry
 from haiku.skills.state import SkillRunDeps, compute_state_delta
+
+logger = logging.getLogger(__name__)
 
 SCRIPT_RUNNERS: dict[str, tuple[str, ...]] = {
     ".py": (sys.executable,),
@@ -210,6 +217,56 @@ def _create_run_script(
     return run_script
 
 
+class _SkillRequestLimitReached(UsageLimitExceeded):
+    """Raised when a skill run reaches its own configured request limit.
+
+    A subclass of ``UsageLimitExceeded`` so it is distinguishable from a
+    ``UsageLimitExceeded`` raised by a nested skill tool (which must propagate as
+    a real failure, not be turned into a forced answer), while still preserving
+    the ``UsageLimitExceeded`` contract when ``force_final_answer`` is off.
+    """
+
+
+@dataclass
+class _RequestLimitGuard(AbstractCapability[Any]):
+    """Enforces the skill's own request limit and captures message history.
+
+    ``before_model_request`` runs on every request, so it owns two jobs:
+    capturing the latest message history (so a forced answer can be seeded with
+    everything gathered so far) and raising ``_SkillRequestLimitReached`` once
+    the request count reaches ``limit``. Bound to a single agent instance, so it
+    is not affected by nested ``capture_run_messages`` contexts in callers.
+    """
+
+    limit: int
+    messages: list[ModelMessage] = field(default_factory=list)
+
+    async def before_model_request(
+        self, ctx: RunContext[Any], request_context: ModelRequestContext
+    ) -> ModelRequestContext:
+        self.messages = list(request_context.messages)
+        if ctx.usage.requests >= self.limit:
+            raise _SkillRequestLimitReached(
+                f"Skill reached its request limit of {self.limit}"
+            )
+        return request_context
+
+
+async def _force_final_answer(
+    model: str | Model,
+    messages: list[ModelMessage],
+    model_settings: ModelSettings | None,
+) -> str:
+    """Make one tool-less completion that forces an answer from gathered context."""
+    agent = Agent[Any, str](model)
+    result = await agent.run(
+        FORCE_FINAL_ANSWER_PROMPT,
+        message_history=messages,
+        model_settings=model_settings,
+    )
+    return result.output
+
+
 async def run_skill(
     model: str | Model,
     skill: Skill,
@@ -273,12 +330,13 @@ async def run_skill(
 
     deps_cls = skill._deps_type or SkillRunDeps
     deps = deps_cls(state=state, emit=emit)
+    guard = _RequestLimitGuard(limit=skill.request_limit or 20)
     agent = Agent[Any, str](
         model,
         system_prompt=system_prompt,
         tools=tools,
         toolsets=skill.toolsets or None,
-        capabilities=[ProcessEventStream(event_handler)],
+        capabilities=[ProcessEventStream(event_handler), guard],
         retries=3,
     )
     model_settings = (
@@ -286,15 +344,39 @@ async def run_skill(
     )
     cm: Any = skill._lifespan(deps) if skill._lifespan is not None else nullcontext()
     async with cm:
-        result = await agent.run(
-            request,
-            deps=deps,
-            usage_limits=UsageLimits(request_limit=skill.request_limit or 20),
-            model_settings=model_settings,
-            conversation_id=conversation_id,
+        try:
+            result = await agent.run(
+                request,
+                deps=deps,
+                model_settings=model_settings,
+                conversation_id=conversation_id,
+            )
+            return result.output, collected_events, emitted_events
+        except _SkillRequestLimitReached:
+            if not skill.force_final_answer:
+                raise
+        except BaseExceptionGroup as eg:
+            if not skill.force_final_answer:
+                raise
+            reached, rest = eg.split(_SkillRequestLimitReached)
+            if reached is None:
+                raise
+            if rest is not None:
+                raise rest
+
+        logger.warning(
+            "Skill '%s' hit its request limit; forcing a final answer.", skill_name
         )
-    text = result.output
-    return text, collected_events, emitted_events
+        try:
+            text = await _force_final_answer(model, guard.messages, model_settings)
+        except Exception as exc:
+            logger.warning(
+                "Skill '%s' forced-answer call failed (%s); propagating.",
+                skill_name,
+                exc,
+            )
+            raise
+        return text, collected_events, emitted_events
 
 
 class SkillToolset(FunctionToolset[Any]):

--- a/haiku/skills/models.py
+++ b/haiku/skills/models.py
@@ -87,6 +87,7 @@ class Skill(BaseModel):
     resources: list[str] = Field(default_factory=list)
     model: str | Model | None = None
     request_limit: int | None = None
+    force_final_answer: bool = True
     _tools: list[Tool | Callable[..., Any]] = PrivateAttr(default_factory=list)
     _toolsets: list[AbstractToolset[Any]] = PrivateAttr(default_factory=list)
     _state_type: type[BaseModel] | None = PrivateAttr(default=None)

--- a/haiku/skills/prompts.py
+++ b/haiku/skills/prompts.py
@@ -53,6 +53,13 @@ def build_system_prompt(
     return template.format(preamble=preamble, skill_catalog=skill_catalog)
 
 
+FORCE_FINAL_ANSWER_PROMPT = """\
+You have reached the tool-call limit, so no tools, resources, or scripts are \
+available to you now. Disregard any earlier instruction to call a tool, read a \
+resource, or run a script. Using only the information you have already gathered \
+above, provide your best and final answer to the task now.\
+"""
+
 SKILL_PROMPT = """\
 You are a focused execution agent. Complete the following task using the \
 skills and instructions provided.

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -12,6 +13,7 @@ from ag_ui.core import (
 )
 from pydantic import BaseModel
 from pydantic_ai import Agent, ModelRetry, RunContext, ToolReturn
+from pydantic_ai.exceptions import UsageLimitExceeded
 from pydantic_ai.messages import (
     FunctionToolCallEvent,
     FunctionToolResultEvent,
@@ -30,6 +32,8 @@ from haiku.skills.agent import (
     _create_read_resource,
     _create_run_script,
     _events_to_activity,
+    _RequestLimitGuard,
+    _SkillRequestLimitReached,
     resolve_model,
     run_agui_stream,
     run_skill,
@@ -722,48 +726,215 @@ class TestRunSkillWithState:
         assert len(captured_settings) == 1
         assert captured_settings[0] is None
 
+    def _captured_guards(self) -> tuple[list[Any], Any]:
+        """Patch Agent.__init__ to capture the _RequestLimitGuard instances."""
+        guards: list[Any] = []
+        original_init = Agent.__init__
+
+        def patched_init(self: Any, *args: Any, **kwargs: Any) -> None:
+            for cap in kwargs.get("capabilities") or []:
+                if isinstance(cap, _RequestLimitGuard):
+                    guards.append(cap)
+            original_init(self, *args, **kwargs)
+
+        return guards, patched_init
+
     async def test_run_skill_default_request_limit_is_20(
         self, allow_model_requests: None
     ):
         """Without skill.request_limit set, run_skill uses the legacy default of 20."""
-        captured_limits: list[Any] = []
-        original_run = Agent.run
-
-        async def patched_run(self: Any, *args: Any, **kwargs: Any) -> Any:
-            captured_limits.append(kwargs.get("usage_limits"))
-            return await original_run(self, *args, **kwargs)
-
+        guards, patched_init = self._captured_guards()
         skill = Skill(
             metadata=SkillMetadata(name="a", description="Test."),
             source=SkillSource.ENTRYPOINT,
             instructions="Do it.",
         )
-        with patch.object(Agent, "run", patched_run):
+        with patch.object(Agent, "__init__", patched_init):
             await run_skill(TestModel(call_tools=[]), skill, "Do it.")
-        assert len(captured_limits) == 1
-        assert captured_limits[0].request_limit == 20
+        assert len(guards) == 1
+        assert guards[0].limit == 20
 
     async def test_run_skill_honors_skill_request_limit(
         self, allow_model_requests: None
     ):
-        """When skill.request_limit is set, run_skill passes it through."""
-        captured_limits: list[Any] = []
-        original_run = Agent.run
-
-        async def patched_run(self: Any, *args: Any, **kwargs: Any) -> Any:
-            captured_limits.append(kwargs.get("usage_limits"))
-            return await original_run(self, *args, **kwargs)
-
+        """When skill.request_limit is set, run_skill uses it as the guard limit."""
+        guards, patched_init = self._captured_guards()
         skill = Skill(
             metadata=SkillMetadata(name="a", description="Test."),
             source=SkillSource.ENTRYPOINT,
             instructions="Do it.",
             request_limit=50,
         )
-        with patch.object(Agent, "run", patched_run):
+        with patch.object(Agent, "__init__", patched_init):
             await run_skill(TestModel(call_tools=[]), skill, "Do it.")
-        assert len(captured_limits) == 1
-        assert captured_limits[0].request_limit == 50
+        assert len(guards) == 1
+        assert guards[0].limit == 50
+
+
+class TestRunSkillForceFinalAnswer:
+    def _burn_skill(self, **kwargs: Any) -> tuple[Skill, list[int]]:
+        calls: list[int] = []
+
+        def burn() -> str:
+            """Burn a request and return gathered data."""
+            calls.append(1)
+            return "gathered data"
+
+        skill = Skill(
+            metadata=SkillMetadata(name="a", description="Test."),
+            source=SkillSource.ENTRYPOINT,
+            instructions="Use burn.",
+            tools=[burn],
+            request_limit=1,
+            **kwargs,
+        )
+        return skill, calls
+
+    async def test_forces_final_answer_on_request_limit(
+        self, allow_model_requests: None
+    ):
+        """Exhausting request_limit yields a forced answer, not an exception."""
+        skill, _ = self._burn_skill()
+        text, _, _ = await run_skill(TestModel(), skill, "Do it.")
+        assert text
+
+    async def test_forcing_call_has_no_tools(self, allow_model_requests: None):
+        """The forcing completion runs with no tools, so the skill tool is not
+        re-invoked beyond the main run."""
+        skill, calls = self._burn_skill()
+        await run_skill(TestModel(), skill, "Do it.")
+        assert len(calls) == 1
+
+    async def test_forcing_logs_warning(
+        self, allow_model_requests: None, caplog: pytest.LogCaptureFixture
+    ):
+        skill, _ = self._burn_skill()
+        with caplog.at_level(logging.WARNING):
+            text, _, _ = await run_skill(TestModel(), skill, "Do it.")
+        assert text
+        assert "forcing a final answer" in caplog.text
+
+    async def test_force_final_answer_false_reraises(self, allow_model_requests: None):
+        skill, _ = self._burn_skill(force_final_answer=False)
+        with pytest.raises(UsageLimitExceeded):
+            await run_skill(TestModel(), skill, "Do it.")
+
+    async def test_nested_tool_usage_limit_propagates(self, allow_model_requests: None):
+        """A UsageLimitExceeded raised by a skill tool is a real failure and must
+        propagate, not be turned into a forced answer."""
+
+        def nested() -> str:
+            """A tool whose own work raises a usage-limit error."""
+            raise UsageLimitExceeded("nested tool limit")
+
+        skill = Skill(
+            metadata=SkillMetadata(name="a", description="Test."),
+            source=SkillSource.ENTRYPOINT,
+            instructions="Use nested.",
+            tools=[nested],
+            request_limit=20,
+        )
+        with pytest.raises((UsageLimitExceeded, BaseExceptionGroup)) as exc_info:
+            await run_skill(TestModel(), skill, "Do it.")
+        exc = exc_info.value
+        leaves = exc.exceptions if isinstance(exc, BaseExceptionGroup) else [exc]
+        assert any("nested tool limit" in str(e) for e in leaves)
+        assert not any(isinstance(e, _SkillRequestLimitReached) for e in leaves)
+
+    async def test_pure_exception_group_forces_answer(self, allow_model_requests: None):
+        """A group whose only leaf is the skill's own limit forces an answer."""
+        original_run = Agent.run
+        calls = {"n": 0}
+
+        async def patched_run(self: Any, *args: Any, **kwargs: Any) -> Any:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise ExceptionGroup("g", [_SkillRequestLimitReached("limit")])
+            return await original_run(self, *args, **kwargs)
+
+        skill = Skill(
+            metadata=SkillMetadata(name="a", description="Test."),
+            source=SkillSource.ENTRYPOINT,
+            instructions="Do it.",
+        )
+        with patch.object(Agent, "run", patched_run):
+            text, _, _ = await run_skill(TestModel(call_tools=[]), skill, "Do it.")
+        assert text
+
+    async def test_mixed_exception_group_reraises_siblings(
+        self, allow_model_requests: None
+    ):
+        """A group with a real sibling failure propagates that sibling, not a
+        forced answer."""
+
+        async def patched_run(self: Any, *args: Any, **kwargs: Any) -> Any:
+            raise ExceptionGroup(
+                "g", [_SkillRequestLimitReached("limit"), ValueError("real")]
+            )
+
+        skill = Skill(
+            metadata=SkillMetadata(name="a", description="Test."),
+            source=SkillSource.ENTRYPOINT,
+            instructions="Do it.",
+        )
+        with patch.object(Agent, "run", patched_run):
+            with pytest.raises(BaseExceptionGroup) as exc_info:
+                await run_skill(TestModel(call_tools=[]), skill, "Do it.")
+        leaves = [type(e).__name__ for e in exc_info.value.exceptions]
+        assert leaves == ["ValueError"]
+
+    async def test_exception_group_without_skill_limit_reraises(
+        self, allow_model_requests: None
+    ):
+        async def patched_run(self: Any, *args: Any, **kwargs: Any) -> Any:
+            raise ExceptionGroup("g", [ValueError("real")])
+
+        skill = Skill(
+            metadata=SkillMetadata(name="a", description="Test."),
+            source=SkillSource.ENTRYPOINT,
+            instructions="Do it.",
+        )
+        with patch.object(Agent, "run", patched_run):
+            with pytest.raises(BaseExceptionGroup) as exc_info:
+                await run_skill(TestModel(call_tools=[]), skill, "Do it.")
+        leaves = [type(e).__name__ for e in exc_info.value.exceptions]
+        assert leaves == ["ValueError"]
+
+    async def test_force_false_group_reraises(self, allow_model_requests: None):
+        async def patched_run(self: Any, *args: Any, **kwargs: Any) -> Any:
+            raise ExceptionGroup("g", [_SkillRequestLimitReached("limit")])
+
+        skill = Skill(
+            metadata=SkillMetadata(name="a", description="Test."),
+            source=SkillSource.ENTRYPOINT,
+            instructions="Do it.",
+            force_final_answer=False,
+        )
+        with patch.object(Agent, "run", patched_run):
+            with pytest.raises(BaseExceptionGroup):
+                await run_skill(TestModel(call_tools=[]), skill, "Do it.")
+
+    async def test_forcing_call_failure_propagates(
+        self, allow_model_requests: None, caplog: pytest.LogCaptureFixture
+    ):
+        calls = {"n": 0}
+
+        async def patched_run(self: Any, *args: Any, **kwargs: Any) -> Any:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise _SkillRequestLimitReached("limit")
+            raise RuntimeError("forcing boom")
+
+        skill = Skill(
+            metadata=SkillMetadata(name="a", description="Test."),
+            source=SkillSource.ENTRYPOINT,
+            instructions="Do it.",
+        )
+        with patch.object(Agent, "run", patched_run):
+            with caplog.at_level(logging.WARNING):
+                with pytest.raises(RuntimeError, match="forcing boom"):
+                    await run_skill(TestModel(call_tools=[]), skill, "Do it.")
+        assert "forced-answer call failed" in caplog.text
 
 
 class TestRunSkillDepsType:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -217,6 +217,18 @@ class TestSkill:
         skill = Skill(metadata=meta, source=SkillSource.FILESYSTEM, request_limit=100)
         assert skill.request_limit == 100
 
+    def test_force_final_answer_default_true(self):
+        meta = SkillMetadata(name="test", description="Test skill.")
+        skill = Skill(metadata=meta, source=SkillSource.FILESYSTEM)
+        assert skill.force_final_answer is True
+
+    def test_force_final_answer_settable(self):
+        meta = SkillMetadata(name="test", description="Test skill.")
+        skill = Skill(
+            metadata=meta, source=SkillSource.FILESYSTEM, force_final_answer=False
+        )
+        assert skill.force_final_answer is False
+
     def test_resources_settable(self):
         meta = SkillMetadata(name="test", description="Test skill.")
         skill = Skill(metadata=meta, source=SkillSource.FILESYSTEM)


### PR DESCRIPTION
  When a skill agent reaches its own request limit, run_skill now makes one
  tool-less completion seeded with the gathered message history instead of
  letting the failure propagate as a null. Gated by Skill.force_final_answer
  (default True).

  The limit is enforced by a per-agent _RequestLimitGuard capability that
  raises a private _SkillRequestLimitReached (a UsageLimitExceeded subclass),
  so a UsageLimitExceeded raised by a nested skill tool stays a real failure
  rather than being converted into a forced answer. History is captured in the
  same capability hook, keeping agent.run() and its AG-UI event streaming
  intact; mixed ExceptionGroups re-raise real sibling failures.