### PR TITLE
Rebase client-edited state with a snapshot at run start

### DIFF
--- a/haiku/skills/agent.py
+++ b/haiku/skills/agent.py
@@ -860,7 +860,12 @@ class AguiEventStream:
         incoming = getattr(run_input, "state", None)
         if not isinstance(incoming, dict) or not incoming:
             return None
-        toolset.restore_state_snapshot(incoming)
+        try:
+            toolset.restore_state_snapshot(incoming)
+        except Exception:
+            # Invalid inbound state: skip the rebase and let the run surface
+            # the validation error as a RUN_ERROR event as usual.
+            return None
         recomputed = toolset.build_state_snapshot()
         drifted = any(incoming.get(ns) != value for ns, value in recomputed.items())
         if not drifted:

--- a/haiku/skills/agent.py
+++ b/haiku/skills/agent.py
@@ -17,6 +17,7 @@ from ag_ui.core import (
     ActivitySnapshotEvent,
     BaseEvent,
     EventType,
+    StateSnapshotEvent,
 )
 from pydantic import BaseModel
 from pydantic_ai import Agent, RunContext, Tool, ToolReturn
@@ -818,18 +819,56 @@ class AguiEventStream:
         if self._toolset is not None:
             self._toolset._event_sink = event_sink
 
+        # If the client sent state that our skills' validation corrects,
+        # re-establish the baseline with a STATE_SNAPSHOT before any
+        # per-tool deltas (which are diffed against the recomputed state).
+        rebase_event = self._rebase_snapshot_event()
+
         async def run_adapter() -> None:
+            pending_rebase = rebase_event
             try:
                 async for event in self._adapter.run_stream(**self._run_kwargs):
                     if isinstance(event, BaseEvent):
                         self._queue.put_nowait(event)
+                        if (
+                            pending_rebase is not None
+                            and event.type == EventType.RUN_STARTED
+                        ):
+                            self._queue.put_nowait(pending_rebase)
+                            pending_rebase = None
             finally:
+                if pending_rebase is not None:
+                    self._queue.put_nowait(pending_rebase)
                 if self._toolset is not None:
                     self._toolset._event_sink = None
                 self._queue.put_nowait(None)
 
         self._task = asyncio.create_task(run_adapter())
         return self
+
+    def _rebase_snapshot_event(self) -> BaseEvent | None:
+        """Restore the client-sent state, recompute it, and return a
+        STATE_SNAPSHOT if validation changed it (so the client rebases).
+
+        Returns None when there is no toolset, no inbound state, or the
+        inbound state already matches what validation produces.
+        """
+        toolset = self._toolset
+        if toolset is None:
+            return None
+        run_input = getattr(self._adapter, "run_input", None)
+        incoming = getattr(run_input, "state", None)
+        if not isinstance(incoming, dict) or not incoming:
+            return None
+        toolset.restore_state_snapshot(incoming)
+        recomputed = toolset.build_state_snapshot()
+        drifted = any(incoming.get(ns) != value for ns, value in recomputed.items())
+        if not drifted:
+            return None
+        return StateSnapshotEvent(
+            type=EventType.STATE_SNAPSHOT,
+            snapshot={**incoming, **recomputed},
+        )
 
     async def __aexit__(self, *exc_info: Any) -> None:
         if self._toolset is not None:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1997,6 +1997,103 @@ class TestRunAguiStream:
                 break
         assert toolset._event_sink is None
 
+    async def test_emits_rebase_snapshot_on_drift(self):
+        """Client-sent state that validation corrects gets a STATE_SNAPSHOT
+        rebase after RUN_STARTED (before any tool-level deltas)."""
+        from types import SimpleNamespace
+
+        from ag_ui.core import (
+            RunFinishedEvent,
+            RunStartedEvent,
+            StateSnapshotEvent,
+        )
+        from pydantic import model_validator
+
+        class DerivedState(BaseModel):
+            items: list[str] = []
+            count: int = 0
+
+            @model_validator(mode="after")
+            def _recompute(self) -> "DerivedState":
+                self.count = len(self.items)
+                return self
+
+        skill = Skill(
+            metadata=SkillMetadata(name="d", description="Derived."),
+            source=SkillSource.ENTRYPOINT,
+            instructions="x",
+            state_type=DerivedState,
+            state_namespace="derived",
+        )
+        toolset = SkillToolset(skills=[skill])
+        # Client sent items but a stale derived count.
+        incoming = {"derived": {"items": ["a", "b"], "count": 0}}
+
+        class FakeAdapter:
+            run_input = SimpleNamespace(state=incoming)
+
+            async def run_stream(self, **kwargs: Any) -> AsyncIterator[BaseEvent]:
+                yield RunStartedEvent(
+                    type=EventType.RUN_STARTED, thread_id="t", run_id="r"
+                )
+                yield RunFinishedEvent(
+                    type=EventType.RUN_FINISHED, thread_id="t", run_id="r"
+                )
+
+        collected: list[BaseEvent] = []
+        async with run_agui_stream(adapter=FakeAdapter(), toolset=toolset) as stream:
+            async for e in stream:
+                collected.append(e)
+
+        snapshots = [e for e in collected if isinstance(e, StateSnapshotEvent)]
+        assert len(snapshots) == 1
+        assert snapshots[0].snapshot["derived"]["count"] == 2
+        types = [getattr(e, "type", None) for e in collected]
+        assert types.index(EventType.STATE_SNAPSHOT) > types.index(
+            EventType.RUN_STARTED
+        )
+
+    async def test_no_rebase_snapshot_when_consistent(self):
+        """No snapshot when the client-sent state already matches validation."""
+        from types import SimpleNamespace
+
+        from ag_ui.core import RunStartedEvent, StateSnapshotEvent
+        from pydantic import model_validator
+
+        class DerivedState(BaseModel):
+            items: list[str] = []
+            count: int = 0
+
+            @model_validator(mode="after")
+            def _recompute(self) -> "DerivedState":
+                self.count = len(self.items)
+                return self
+
+        skill = Skill(
+            metadata=SkillMetadata(name="d", description="Derived."),
+            source=SkillSource.ENTRYPOINT,
+            instructions="x",
+            state_type=DerivedState,
+            state_namespace="derived",
+        )
+        toolset = SkillToolset(skills=[skill])
+        incoming = {"derived": {"items": ["a"], "count": 1}}  # consistent
+
+        class FakeAdapter:
+            run_input = SimpleNamespace(state=incoming)
+
+            async def run_stream(self, **kwargs: Any) -> AsyncIterator[BaseEvent]:
+                yield RunStartedEvent(
+                    type=EventType.RUN_STARTED, thread_id="t", run_id="r"
+                )
+
+        collected: list[BaseEvent] = []
+        async with run_agui_stream(adapter=FakeAdapter(), toolset=toolset) as stream:
+            async for e in stream:
+                collected.append(e)
+
+        assert not [e for e in collected if isinstance(e, StateSnapshotEvent)]
+
 
 def _make_run_input(message: str) -> Any:
     """Create a minimal RunAgentInput for testing."""

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2157,6 +2157,51 @@ class TestRunAguiStream:
         assert len(snapshots) == 1
         assert snapshots[0].snapshot["derived"]["count"] == 2
 
+    async def test_invalid_inbound_state_does_not_leak_sink(self):
+        """Invalid client state must not raise out of __aenter__ or leave the
+        event sink attached; the run surfaces the error normally instead."""
+        from types import SimpleNamespace
+
+        from ag_ui.core import RunStartedEvent, StateSnapshotEvent
+        from pydantic import model_validator
+
+        class DerivedState(BaseModel):
+            items: list[str] = []
+            count: int = 0
+
+            @model_validator(mode="after")
+            def _recompute(self) -> "DerivedState":
+                self.count = len(self.items)
+                return self
+
+        skill = Skill(
+            metadata=SkillMetadata(name="d", description="Derived."),
+            source=SkillSource.ENTRYPOINT,
+            instructions="x",
+            state_type=DerivedState,
+            state_namespace="derived",
+        )
+        toolset = SkillToolset(skills=[skill])
+        # Not coercible to int -> ValidationError during restore.
+        incoming = {"derived": {"count": "not-an-int"}}
+
+        class FakeAdapter:
+            run_input = SimpleNamespace(state=incoming)
+
+            async def run_stream(self, **kwargs: Any) -> AsyncIterator[BaseEvent]:
+                yield RunStartedEvent(
+                    type=EventType.RUN_STARTED, thread_id="t", run_id="r"
+                )
+
+        collected: list[BaseEvent] = []
+        async with run_agui_stream(adapter=FakeAdapter(), toolset=toolset) as stream:
+            async for e in stream:
+                collected.append(e)
+
+        # No rebase snapshot (state was invalid), and the sink is released.
+        assert not [e for e in collected if isinstance(e, StateSnapshotEvent)]
+        assert toolset._event_sink is None
+
 
 def _make_run_input(message: str) -> Any:
     """Create a minimal RunAgentInput for testing."""

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -2094,6 +2094,69 @@ class TestRunAguiStream:
 
         assert not [e for e in collected if isinstance(e, StateSnapshotEvent)]
 
+    async def test_no_rebase_snapshot_without_toolset(self):
+        """With no toolset there is nothing to rebase, even with inbound state."""
+        from types import SimpleNamespace
+
+        from ag_ui.core import RunStartedEvent, StateSnapshotEvent
+
+        class FakeAdapter:
+            run_input = SimpleNamespace(state={"whatever": {"a": 1}})
+
+            async def run_stream(self, **kwargs: Any) -> AsyncIterator[BaseEvent]:
+                yield RunStartedEvent(
+                    type=EventType.RUN_STARTED, thread_id="t", run_id="r"
+                )
+
+        collected: list[BaseEvent] = []
+        async with run_agui_stream(adapter=FakeAdapter(), toolset=None) as stream:
+            async for e in stream:
+                collected.append(e)
+
+        assert not [e for e in collected if isinstance(e, StateSnapshotEvent)]
+
+    async def test_rebase_snapshot_emitted_without_run_started(self):
+        """The rebase snapshot still flushes when the run yields no RUN_STARTED."""
+        from types import SimpleNamespace
+
+        from ag_ui.core import StateSnapshotEvent
+        from pydantic import model_validator
+
+        class DerivedState(BaseModel):
+            items: list[str] = []
+            count: int = 0
+
+            @model_validator(mode="after")
+            def _recompute(self) -> "DerivedState":
+                self.count = len(self.items)
+                return self
+
+        skill = Skill(
+            metadata=SkillMetadata(name="d", description="Derived."),
+            source=SkillSource.ENTRYPOINT,
+            instructions="x",
+            state_type=DerivedState,
+            state_namespace="derived",
+        )
+        toolset = SkillToolset(skills=[skill])
+        incoming = {"derived": {"items": ["a", "b"], "count": 0}}
+
+        class FakeAdapter:
+            run_input = SimpleNamespace(state=incoming)
+
+            async def run_stream(self, **kwargs: Any) -> AsyncIterator[BaseEvent]:
+                if False:  # yields nothing; no RUN_STARTED
+                    yield  # type: ignore[unreachable]
+
+        collected: list[BaseEvent] = []
+        async with run_agui_stream(adapter=FakeAdapter(), toolset=toolset) as stream:
+            async for e in stream:
+                collected.append(e)
+
+        snapshots = [e for e in collected if isinstance(e, StateSnapshotEvent)]
+        assert len(snapshots) == 1
+        assert snapshots[0].snapshot["derived"]["count"] == 2
+
 
 def _make_run_input(message: str) -> Any:
     """Create a minimal RunAgentInput for testing."""


### PR DESCRIPTION
## Summary

When a client sends shared state that a skill's own validation corrects (e.g. a UI that edits a field but leaves server-derived fields stale), `AguiEventStream` now emits a `StateSnapshotEvent` at the start of the run to re-establish the baseline, before any per-tool deltas.

## Background

AG-UI shared state is snapshot/delta based: `StateDeltaEvent`s are JSON Patch operations that must apply in sequence against a baseline both sides agree on. Snapshots exist to (re)establish that baseline.

Today the skill toolset restores the client's state at run start (`for_run` → `restore_state_snapshot` → `model_validate`, which runs any validators), then emits per-tool deltas diffed against that *recomputed* baseline. That is fine when the client's state matches what validation produces. But when a client sends state the skill normalizes/derives differently — the common case being a form UI that edits a data field without recomputing the derived fields — two things break:

1. The correction from validation is never sent to the client (it happens at restore, before the tool-delta baseline), so the client's derived fields stay stale.
2. Subsequent index-based list patches (e.g. `remove /missing/1`) are diffed against the server's recomputed array, which no longer matches the client's — so they mis-apply.

## Change

In `AguiEventStream`, before streaming adapter events, restore `run_input.state` and compare the validated result to what the client sent. If any skill-owned namespace differs, emit a `StateSnapshotEvent` (right after `RUN_STARTED`) carrying the canonical state. The client replaces its state with the snapshot; the run's per-tool deltas then apply against that same baseline by construction.

## When it fires

Only when all hold:
- the run has a toolset with state namespaces,
- `run_input.state` is a non-empty dict,
- restoring + validating it changes at least one skill-owned namespace.

It does **not** fire for stateless skills, or when the inbound state already matches validation (every server-originated turn — normal chat and read-only flows).

## Effect on existing skills

- Stateless skills: never fires; no change.
- Stateful skills whose clients only echo server state: no drift; no snapshot; no change.
- Stateful skills with a validator/derivation and a client that sends modified state: get a corrective rebase (previously they diverged silently).

`restore_state_snapshot` now also runs once at run start, in addition to `for_run`'s restore. It is idempotent (validate twice → same result) and only when there is inbound state.

## Testing

- New `TestRunAguiStream` cases: snapshot emitted after `RUN_STARTED` with the corrected value when inbound state drifts; no snapshot when it is already consistent.
- Full `tests/test_agent.py` passes; `ruff` and `ty` clean.
- Verified end-to-end against soliplex + a local model: a client edit that left derived state stale is corrected via the emitted snapshot, even on a turn with no tool call.
